### PR TITLE
[#17] 카카오 로그인, 로컬 저장소 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,4 +61,5 @@ dependencies {
 
     implementation(libs.hilt)
     kapt(libs.hilt.compiler)
+    implementation(libs.kakao.login)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import com.mashup.gabbangzip.sharedalbum.buildsrc.AppConfig
 
 plugins {
@@ -17,6 +18,17 @@ android {
         targetSdk = AppConfig.targetSdk
         versionCode = AppConfig.appVersionCode
         versionName = AppConfig.appVersionName
+
+        buildConfigField(
+            type = "String",
+            name = "KAKAO_NATIVE_APP_KEY",
+            value = "\"${
+                gradleLocalProperties(
+                    rootDir,
+                    providers,
+                ).getProperty("kakao_native_app_key")
+            }\"",
+        )
 
         testInstrumentationRunner = AppConfig.testRunner
         vectorDrawables {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,12 +22,7 @@ android {
         buildConfigField(
             type = "String",
             name = "KAKAO_NATIVE_APP_KEY",
-            value = "\"${
-                gradleLocalProperties(
-                    rootDir,
-                    providers,
-                ).getProperty("kakao_native_app_key")
-            }\"",
+            value = "\"${gradleLocalProperties(rootDir, providers).getProperty("kakao_native_app_key")}\"",
         )
 
         testInstrumentationRunner = AppConfig.testRunner

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,4 +74,5 @@ dependencies {
     implementation(libs.hilt)
     kapt(libs.hilt.compiler)
     implementation(libs.kakao.login)
+    implementation(libs.androidx.security.crypto)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".MainApplication"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".MainApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -10,6 +11,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/Theme.SharedAlbum"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
 
     </application>

--- a/app/src/main/java/com/mashup/gabbangzip/sharedalbum/MainApplication.kt
+++ b/app/src/main/java/com/mashup/gabbangzip/sharedalbum/MainApplication.kt
@@ -1,0 +1,13 @@
+package com.mashup.gabbangzip.sharedalbum
+
+import android.app.Application
+import com.kakao.sdk.common.KakaoSdk
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MainApplication: Application() {
+    override fun onCreate() {
+        super.onCreate()
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+    }
+}

--- a/app/src/main/java/com/mashup/gabbangzip/sharedalbum/MainApplication.kt
+++ b/app/src/main/java/com/mashup/gabbangzip/sharedalbum/MainApplication.kt
@@ -5,7 +5,7 @@ import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class MainApplication: Application() {
+class MainApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -59,4 +59,7 @@ dependencies {
 
     // coroutine
     implementation(libs.bundles.coroutine)
+
+    // encrypted shared preferences
+    implementation(libs.androidx.security.crypto)
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
@@ -1,0 +1,16 @@
+package com.mashup.gabbangzip.sharedalbum.data.base
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PicResponse<T>(
+    val isSuccess: Boolean,
+    val data: T?,
+    val errorResponse: PicErrorResponse?,
+)
+
+@JsonClass(generateAdapter = true)
+data class PicErrorResponse(
+    val code: String,
+    val message: String,
+)

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
@@ -1,16 +1,22 @@
 package com.mashup.gabbangzip.sharedalbum.data.base
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class PicResponse<T>(
+    @Json(name = "isSuccess")
     val isSuccess: Boolean,
+    @Json(name = "data")
     val data: T?,
+    @Json(name = "errorResponse")
     val errorResponse: PicErrorResponse?,
 )
 
 @JsonClass(generateAdapter = true)
 data class PicErrorResponse(
+    @Json(name = "code")
     val code: String,
+    @Json(name = "message")
     val message: String,
 )

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/datasource/LocalDataSourceImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/datasource/LocalDataSourceImpl.kt
@@ -73,12 +73,12 @@ class LocalDataSourceImpl @Inject constructor(
         }
     }
 
-    private fun getString(key: String, defaultValue: String): String {
+    private fun getString(key: String, defaultValue: String = ""): String {
         return getStringOrNull(key, defaultValue) ?: defaultValue
     }
 
     @Synchronized
-    private fun getStringOrNull(key: String, defaultValue: String?): String? {
+    private fun getStringOrNull(key: String, defaultValue: String? = null): String? {
         return sharedPreferences.getString(key, defaultValue).also {
             Log.d(TAG, "getStringOrNull: key: $key, value: $it")
         }
@@ -108,6 +108,12 @@ class LocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override fun removeAll() {
+        sharedPreferences.edit {
+            clear()
+        }
+    }
+
     override fun saveToken(accessToken: String, refreshToken: String) {
         putString(KEY_ACCESS_TOKEN, accessToken)
         putString(KEY_REFRESH_TOKEN, refreshToken)
@@ -118,10 +124,12 @@ class LocalDataSourceImpl @Inject constructor(
         remove(KEY_REFRESH_TOKEN)
     }
 
-    override fun removeAll() {
-        sharedPreferences.edit {
-            clear()
-        }
+    override fun getAccessToken(): String? {
+        return getStringOrNull(KEY_ACCESS_TOKEN)
+    }
+
+    override fun getRefreshToken(): String? {
+        return getStringOrNull(KEY_REFRESH_TOKEN)
     }
 
     companion object {

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/datasource/LocalDataSourceImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/datasource/LocalDataSourceImpl.kt
@@ -1,0 +1,121 @@
+package com.mashup.gabbangzip.sharedalbum.data.datasource
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.core.content.edit
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class LocalDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : LocalDataSource {
+    private val sharedPreferences: SharedPreferences by lazy {
+        val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
+        val masterKeyAlias = MasterKeys.getOrCreate(keyGenParameterSpec)
+
+        EncryptedSharedPreferences.create(
+            PREF_NAME,
+            masterKeyAlias,
+            context,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    /**
+     * Int
+     */
+    @Synchronized
+    private fun putInt(key: String, value: Int) {
+        Log.d(TAG, "putInt: key: $key, value: $value")
+        sharedPreferences.edit {
+            putInt(key, value)
+        }
+    }
+
+    @Synchronized
+    private fun getInt(key: String, defaultValue: Int): Int {
+        return sharedPreferences.getInt(key, defaultValue).also {
+            Log.d(TAG, "getInt: key: $key, value: $it")
+        }
+    }
+
+    /**
+     * Long
+     */
+    @Synchronized
+    private fun putLong(key: String, value: Long) {
+        Log.d(TAG, "putLong: key: $key, value: $value")
+        sharedPreferences.edit {
+            putLong(key, value)
+        }
+    }
+
+    @Synchronized
+    private fun getLong(key: String, defaultValue: Long): Long {
+        return sharedPreferences.getLong(key, defaultValue).also {
+            Log.d(TAG, "getLong: key: $key, value: $it")
+        }
+    }
+
+    /**
+     * String
+     */
+    @Synchronized
+    private fun putString(key: String, value: String?) {
+        Log.d(TAG, "putString: key: $key, value: $value")
+        sharedPreferences.edit {
+            putString(key, value)
+        }
+    }
+
+    private fun getString(key: String, defaultValue: String): String {
+        return getStringOrNull(key, defaultValue) ?: defaultValue
+    }
+
+    @Synchronized
+    private fun getStringOrNull(key: String, defaultValue: String?): String? {
+        return sharedPreferences.getString(key, defaultValue).also {
+            Log.d(TAG, "getStringOrNull: key: $key, value: $it")
+        }
+    }
+
+    /**
+     * Boolean
+     */
+    @Synchronized
+    private fun putBoolean(key: String, value: Boolean) {
+        Log.d(TAG, "putBoolean: key: $key, value: $value")
+        sharedPreferences.edit {
+            putBoolean(key, value)
+        }
+    }
+
+    @Synchronized
+    private fun getBoolean(key: String, defaultValue: Boolean): Boolean {
+        return sharedPreferences.getBoolean(key, defaultValue).also {
+            Log.d(TAG, "getBoolean: key: $key, value: $it")
+        }
+    }
+
+    private fun remove(key: String) {
+        return sharedPreferences.edit {
+            remove(key)
+        }
+    }
+
+    override fun removeAll() {
+        sharedPreferences.edit {
+            clear()
+        }
+    }
+
+    companion object {
+        private const val TAG = "preferences"
+        private const val PREF_NAME = "pic_preferences"
+    }
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/datasource/LocalDataSourceImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/datasource/LocalDataSourceImpl.kt
@@ -108,6 +108,16 @@ class LocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override fun saveToken(accessToken: String, refreshToken: String) {
+        putString(KEY_ACCESS_TOKEN, accessToken)
+        putString(KEY_REFRESH_TOKEN, refreshToken)
+    }
+
+    override fun removeToken() {
+        remove(KEY_ACCESS_TOKEN)
+        remove(KEY_REFRESH_TOKEN)
+    }
+
     override fun removeAll() {
         sharedPreferences.edit {
             clear()
@@ -117,5 +127,7 @@ class LocalDataSourceImpl @Inject constructor(
     companion object {
         private const val TAG = "preferences"
         private const val PREF_NAME = "pic_preferences"
+        private const val KEY_ACCESS_TOKEN = "key_access_token"
+        private const val KEY_REFRESH_TOKEN = "key_refresh_token"
     }
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/DataSourceModule.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/DataSourceModule.kt
@@ -1,0 +1,17 @@
+package com.mashup.gabbangzip.sharedalbum.data.di
+
+import com.mashup.gabbangzip.sharedalbum.data.datasource.LocalDataSourceImpl
+import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface DataSourceModule {
+    @Singleton
+    @Binds
+    fun bindLocalDataSource(dataSourceImpl: LocalDataSourceImpl): LocalDataSource
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.data.di
 
 import com.mashup.gabbangzip.sharedalbum.data.BuildConfig
+import com.mashup.gabbangzip.sharedalbum.data.interceptor.AuthInterceptor
 import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
 import dagger.Module
 import dagger.Provides
@@ -32,10 +33,12 @@ internal class NetworkModule {
     @Provides
     fun provideOkHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor,
     ): OkHttpClient {
         return OkHttpClient
             .Builder()
             .addInterceptor(httpLoggingInterceptor)
+            .addInterceptor(authInterceptor)
             .build()
     }
 

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/NetworkModule.kt
@@ -1,0 +1,58 @@
+package com.mashup.gabbangzip.sharedalbum.data.di
+
+import com.mashup.gabbangzip.sharedalbum.data.BuildConfig
+import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.create
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal class NetworkModule {
+    @Singleton
+    @Provides
+    fun provideHttpLoggingInterceptor(): HttpLoggingInterceptor {
+        return HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BODY
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
+        }
+    }
+
+    @Singleton
+    @Provides
+    fun provideOkHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient {
+        return OkHttpClient
+            .Builder()
+            .addInterceptor(httpLoggingInterceptor)
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit =
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+
+    @Singleton
+    @Provides
+    fun provideLoginService(retrofit: Retrofit): LoginService = retrofit.create()
+
+    companion object {
+        private const val BASE_URL = "http://3.39.133.214:8080" // TODO("임시서버")
+    }
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/RepositoryModule.kt
@@ -1,0 +1,17 @@
+package com.mashup.gabbangzip.sharedalbum.data.di
+
+import com.mashup.gabbangzip.sharedalbum.data.repository.LoginRepositoryImpl
+import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface RepositoryModule {
+    @Singleton
+    @Binds
+    fun bindLoginRepository(loginRepositoryImpl: LoginRepositoryImpl): LoginRepository
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/request/LoginRequest.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/request/LoginRequest.kt
@@ -1,0 +1,11 @@
+package com.mashup.gabbangzip.sharedalbum.data.dto.request
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class LoginRequest(
+    val idToken: String,
+    val provider: String,
+    val nickname: String,
+    val profileImage: String,
+)

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/request/LoginRequest.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/request/LoginRequest.kt
@@ -1,11 +1,16 @@
 package com.mashup.gabbangzip.sharedalbum.data.dto.request
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class LoginRequest(
+    @Json(name = "idToken")
     val idToken: String,
+    @Json(name = "provider")
     val provider: String,
+    @Json(name = "nickname")
     val nickname: String,
+    @Json(name = "profileImage")
     val profileImage: String,
 )

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/LoginResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/LoginResponse.kt
@@ -1,0 +1,11 @@
+package com.mashup.gabbangzip.sharedalbum.data.dto.response
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class LoginResponse(
+    val userId: Long,
+    val nickname: String,
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/LoginResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/LoginResponse.kt
@@ -1,11 +1,16 @@
 package com.mashup.gabbangzip.sharedalbum.data.dto.response
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class LoginResponse(
+    @Json(name = "userId")
     val userId: Long,
+    @Json(name = "nickname")
     val nickname: String,
+    @Json(name = "accessToken")
     val accessToken: String,
+    @Json(name = "refreshToken")
     val refreshToken: String,
 )

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/interceptor/AuthInterceptor.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/interceptor/AuthInterceptor.kt
@@ -1,0 +1,23 @@
+package com.mashup.gabbangzip.sharedalbum.data.interceptor
+
+import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthInterceptor @Inject constructor(
+    private val localDataSource: LocalDataSource,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = localDataSource.getAccessToken() ?: return chain.proceed(chain.request())
+
+        return chain.proceed(
+            chain.request()
+                .newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build(),
+        )
+    }
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -2,12 +2,14 @@ package com.mashup.gabbangzip.sharedalbum.data.repository
 
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
 import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
+import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
 import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(
     private val loginService: LoginService,
+    private val localDataSource: LocalDataSource,
 ) : LoginRepository {
     override suspend fun login(param: LoginParam) {
         val request = LoginRequest(
@@ -16,6 +18,22 @@ class LoginRepositoryImpl @Inject constructor(
             nickname = param.nickname,
             profileImage = param.profileImage,
         )
-        loginService.login(loginRequest = request)
+        runCatching {
+            loginService.login(loginRequest = request)
+        }.onSuccess { response ->
+            with(response.data!!) {
+                saveToken(
+                    accessToken = accessToken,
+                    refreshToken = refreshToken,
+                )
+            }
+        }
+    }
+
+    override fun saveToken(accessToken: String, refreshToken: String) {
+        localDataSource.saveToken(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+        )
     }
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -27,7 +27,7 @@ class LoginRepositoryImpl @Inject constructor(
                     refreshToken = refreshToken,
                 )
             }
-        }
+        }.getOrThrow()
     }
 
     override fun saveToken(accessToken: String, refreshToken: String) {

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -21,12 +21,12 @@ class LoginRepositoryImpl @Inject constructor(
         runCatching {
             loginService.login(loginRequest = request)
         }.onSuccess { response ->
-            with(response.data!!) {
+            response.data?.run {
                 saveToken(
                     accessToken = accessToken,
                     refreshToken = refreshToken,
                 )
-            }
+            } ?: throw IllegalStateException("데이터 없음")
         }.getOrThrow()
     }
 

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -1,0 +1,26 @@
+package com.mashup.gabbangzip.sharedalbum.data.repository
+
+import android.util.Log
+import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
+import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
+import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
+import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
+import javax.inject.Inject
+
+private const val TAG = "LoginRepositoryImpl"
+
+class LoginRepositoryImpl @Inject constructor(
+    private val loginService: LoginService,
+) : LoginRepository {
+    override suspend fun login(param: LoginParam) {
+        val request = LoginRequest(
+            idToken = param.idToken,
+            provider = param.provider,
+            nickname = param.nickname,
+            profileImage = param.profileImage,
+        )
+        loginService.login(loginRequest = request).also {
+            Log.d(TAG, "login: $it")
+        }
+    }
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -3,8 +3,8 @@ package com.mashup.gabbangzip.sharedalbum.data.repository
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
 import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
 import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
+import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
 import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
-import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
 import javax.inject.Inject
 
 class LoginRepositoryImpl @Inject constructor(

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -1,13 +1,10 @@
 package com.mashup.gabbangzip.sharedalbum.data.repository
 
-import android.util.Log
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
 import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
 import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
 import javax.inject.Inject
-
-private const val TAG = "LoginRepositoryImpl"
 
 class LoginRepositoryImpl @Inject constructor(
     private val loginService: LoginService,
@@ -19,8 +16,6 @@ class LoginRepositoryImpl @Inject constructor(
             nickname = param.nickname,
             profileImage = param.profileImage,
         )
-        loginService.login(loginRequest = request).also {
-            Log.d(TAG, "login: $it")
-        }
+        loginService.login(loginRequest = request)
     }
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/service/LoginService.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/service/LoginService.kt
@@ -1,0 +1,14 @@
+package com.mashup.gabbangzip.sharedalbum.data.service
+
+import com.mashup.gabbangzip.sharedalbum.data.base.PicResponse
+import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
+import com.mashup.gabbangzip.sharedalbum.data.dto.response.LoginResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface LoginService {
+    @POST("api/v1/auth/login")
+    suspend fun login(
+        @Body loginRequest: LoginRequest,
+    ): PicResponse<LoginResponse>
+}

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/datasource/LocalDataSource.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/datasource/LocalDataSource.kt
@@ -1,7 +1,9 @@
 package com.mashup.gabbangzip.sharedalbum.domain.datasource
 
 interface LocalDataSource {
+    fun removeAll()
     fun saveToken(accessToken: String, refreshToken: String)
     fun removeToken()
-    fun removeAll()
+    fun getAccessToken(): String?
+    fun getRefreshToken(): String?
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/datasource/LocalDataSource.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/datasource/LocalDataSource.kt
@@ -1,0 +1,5 @@
+package com.mashup.gabbangzip.sharedalbum.domain.datasource
+
+interface LocalDataSource {
+    fun removeAll()
+}

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/datasource/LocalDataSource.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/datasource/LocalDataSource.kt
@@ -1,5 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.domain.datasource
 
 interface LocalDataSource {
+    fun saveToken(accessToken: String, refreshToken: String)
+    fun removeToken()
     fun removeAll()
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/model/LoginParam.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/model/LoginParam.kt
@@ -1,0 +1,8 @@
+package com.mashup.gabbangzip.sharedalbum.domain.model
+
+data class LoginParam(
+    val idToken: String,
+    val provider: String = "KAKAO",
+    val nickname: String,
+    val profileImage: String,
+)

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
@@ -4,4 +4,5 @@ import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
 
 interface LoginRepository {
     suspend fun login(param: LoginParam)
+    fun saveToken(accessToken: String, refreshToken: String)
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
@@ -1,6 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.domain.repository
 
-import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
+import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
 
 interface LoginRepository {
     suspend fun login(param: LoginParam)

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
@@ -1,0 +1,7 @@
+package com.mashup.gabbangzip.sharedalbum.domain.repository
+
+import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
+
+interface LoginRepository {
+    suspend fun login(param: LoginParam)
+}

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/LoginUseCase.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/LoginUseCase.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.domain.usecase
 
+import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
 import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
 import javax.inject.Inject
 
@@ -10,10 +11,3 @@ class LoginUseCase @Inject constructor(
         return runCatching { loginRepository.login(param) }
     }
 }
-
-data class LoginParam(
-    val idToken: String,
-    val provider: String = "KAKAO",
-    val nickname: String,
-    val profileImage: String,
-)

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/LoginUseCase.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/LoginUseCase.kt
@@ -1,0 +1,19 @@
+package com.mashup.gabbangzip.sharedalbum.domain.usecase
+
+import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
+import javax.inject.Inject
+
+class LoginUseCase @Inject constructor(
+    private val loginRepository: LoginRepository,
+) {
+    suspend operator fun invoke(param: LoginParam): Result<Unit> {
+        return runCatching { loginRepository.login(param) }
+    }
+}
+
+data class LoginParam(
+    val idToken: String,
+    val provider: String = "KAKAO",
+    val nickname: String,
+    val profileImage: String,
+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ coroutine = "1.7.3"
 room = "2.6.1"
 
 ktlint = "11.6.1"
+kakaoLogin = "2.20.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -72,6 +73,8 @@ coroutine-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutine
 
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+
+kakao-login = { module = "com.kakao.sdk:v2-user", version.ref = "kakaoLogin" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,9 +34,11 @@ room = "2.6.1"
 
 ktlint = "11.6.1"
 kakaoLogin = "2.20.1"
+securityCrypto = "1.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "securityCrypto" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 import com.mashup.gabbangzip.sharedalbum.buildsrc.AppConfig
 
 plugins {
@@ -13,6 +14,8 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
+        manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] =
+            gradleLocalProperties(rootDir, providers).getProperty("kakao_native_app_key")
 
         testInstrumentationRunner = AppConfig.testRunner
         consumerProguardFiles("consumer-rules.pro")

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -67,4 +67,5 @@ dependencies {
 
     // coroutine
     implementation(libs.bundles.coroutine)
+    implementation(libs.kakao.login)
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -10,6 +10,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/auth/KakaoUserSdkUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/auth/KakaoUserSdkUtil.kt
@@ -77,9 +77,7 @@ object KakaoUserSdkUtil {
             } else if (user != null) {
                 Log.i(
                     TAG,
-                    "사용자 정보 요청 성공" +
-                            "\n닉네임: ${user.kakaoAccount?.profile?.nickname}" +
-                            "\n프로필사진: ${user.kakaoAccount?.profile?.thumbnailImageUrl}",
+                    "사용자 정보 요청 성공\n닉네임: ${user.kakaoAccount?.profile?.nickname}\n프로필사진: ${user.kakaoAccount?.profile?.thumbnailImageUrl}",
                 )
                 onSuccess(user.kakaoAccount?.profile)
             }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/auth/KakaoUserSdkUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/auth/KakaoUserSdkUtil.kt
@@ -1,0 +1,119 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.auth
+
+import android.content.Context
+import android.util.Log
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import com.kakao.sdk.user.model.Profile
+
+/**
+ * 카카오 로그인 유틸
+ * https://developers.kakao.com/docs/latest/ko/kakaologin/android
+ */
+object KakaoUserSdkUtil {
+    private const val TAG = "카카오 로그인 테스트"
+
+    fun loginWithKakao(
+        context: Context,
+        onSuccess: (idToken: String?, profile: Profile?) -> Unit,
+        onFailure: (Throwable?) -> Unit,
+    ) = with(UserApiClient.instance) {
+        val callback = createKakaoAuthCallback(onSuccess, onFailure)
+
+        if (isKakaoTalkLoginAvailable(context)) {
+            loginWithKakaoTalk(context) { token, error ->
+                if (error != null) {
+                    Log.e(TAG, "카카오톡으로 로그인 실패", error)
+
+                    // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
+                    // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        return@loginWithKakaoTalk
+                    }
+
+                    // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                    loginWithKakaoAccount(context, callback = callback)
+                } else if (token != null) {
+                    Log.i(TAG, "카카오톡으로 로그인 성공 ${token.idToken}")
+                    callback(token, null)
+                }
+            }
+        } else {
+            loginWithKakaoAccount(context, callback = callback)
+        }
+    }
+
+    private fun createKakaoAuthCallback(
+        onSuccess: (idToken: String?, profile: Profile?) -> Unit,
+        onFailure: (Throwable?) -> Unit = {},
+    ): (OAuthToken?, Throwable?) -> Unit {
+        val kakaoOAuthCallback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+            if (error != null) {
+                Log.e(TAG, "카카오계정으로 로그인 실패", error)
+                onFailure(error)
+            } else if (token != null) {
+                Log.i(TAG, "카카오계정으로 로그인 성공 ${token.idToken}")
+                getKakaoUserProfile(
+                    onSuccess = { profile ->
+                        onSuccess(token.idToken, profile)
+                    },
+                    onFailure = onFailure,
+                )
+            }
+        }
+        return kakaoOAuthCallback
+    }
+
+    private fun getKakaoUserProfile(
+        onSuccess: (Profile?) -> Unit,
+        onFailure: (Throwable?) -> Unit = {},
+    ) {
+        UserApiClient.instance.me { user, error ->
+            if (error != null) {
+                Log.e(TAG, "사용자 정보 요청 실패", error)
+                onFailure(error)
+            } else if (user != null) {
+                Log.i(
+                    TAG,
+                    "사용자 정보 요청 성공" +
+                            "\n닉네임: ${user.kakaoAccount?.profile?.nickname}" +
+                            "\n프로필사진: ${user.kakaoAccount?.profile?.thumbnailImageUrl}",
+                )
+                onSuccess(user.kakaoAccount?.profile)
+            }
+        }
+    }
+
+    /**
+     * 로그아웃
+     */
+    fun logout() {
+        UserApiClient.instance.logout { error ->
+            if (error != null) {
+                Log.e(TAG, "로그아웃 실패. SDK에서 토큰 삭제됨", error)
+            } else {
+                Log.i(TAG, "로그아웃 성공. SDK에서 토큰 삭제됨")
+            }
+        }
+    }
+
+    /**
+     * 회원탈퇴 시, 카카오계정 연결 끊기
+     */
+    fun withdrawal(
+        onSuccess: () -> Unit = {},
+        onFailure: (Throwable?) -> Unit = {},
+    ) {
+        UserApiClient.instance.unlink { error ->
+            if (error != null) {
+                Log.e(TAG, "연결 끊기 실패", error)
+                onFailure(error)
+            } else {
+                Log.i(TAG, "연결 끊기 성공. SDK에서 토큰 삭제 됨")
+                onSuccess()
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
@@ -22,7 +22,7 @@ class LoginViewModel @Inject constructor(
         KakaoUserSdkUtil.loginWithKakao(
             context = context,
             onSuccess = { idToken, profile ->
-                if (idToken != null && profile?.nickname != null && profile.profileImageUrl != null) {
+                if (profile.nickname != null && profile.profileImageUrl != null) {
                     picLogin(
                         idToken = idToken,
                         nickname = profile.nickname!!,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
@@ -22,11 +22,13 @@ class LoginViewModel @Inject constructor(
         KakaoUserSdkUtil.loginWithKakao(
             context = context,
             onSuccess = { idToken, profile ->
-                if (profile.nickname != null && profile.profileImageUrl != null) {
+                val nickname = profile.nickname
+                val profileImage = profile.profileImageUrl
+                if (nickname != null && profileImage != null) {
                     picLogin(
                         idToken = idToken,
-                        nickname = profile.nickname!!,
-                        profileImage = profile.profileImageUrl!!,
+                        nickname = nickname,
+                        profileImage = profileImage,
                     )
                 } else {
                     Log.d(TAG, "정보 조회 실패")

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kakao.sdk.user.model.Profile
-import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
+import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginUseCase
 import com.mashup.gabbangzip.sharedalbum.presentation.auth.KakaoUserSdkUtil
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
@@ -1,0 +1,55 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.login
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kakao.sdk.user.model.Profile
+import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginParam
+import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginUseCase
+import com.mashup.gabbangzip.sharedalbum.presentation.auth.KakaoUserSdkUtil
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val loginUseCase: LoginUseCase,
+) : ViewModel() {
+
+    fun login() {
+        KakaoUserSdkUtil.loginWithKakao(
+            context = context,
+            onSuccess = { idToken, profile ->
+                if (idToken != null && profile != null) {
+                    picLogin(idToken, profile)
+                }
+            },
+            onFailure = {
+                Log.d(TAG, "카카오 로그인 실패 또는 정보 조회 실패 $it")
+            },
+        )
+    }
+
+    private fun picLogin(idToken: String, profile: Profile) {
+        val param = LoginParam(
+            idToken = idToken,
+            nickname = profile.nickname!!,
+            profileImage = profile.profileImageUrl!!,
+        )
+        viewModelScope.launch {
+            loginUseCase(param)
+                .onSuccess {
+                    Log.d(TAG, "로그인 성공")
+                }.onFailure {
+                    Log.d(TAG, "로그인 실패 $it")
+                }
+        }
+    }
+
+    companion object {
+        private const val TAG = "LoginViewModel"
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/login/LoginViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.kakao.sdk.user.model.Profile
 import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginUseCase
 import com.mashup.gabbangzip.sharedalbum.presentation.auth.KakaoUserSdkUtil
@@ -23,8 +22,14 @@ class LoginViewModel @Inject constructor(
         KakaoUserSdkUtil.loginWithKakao(
             context = context,
             onSuccess = { idToken, profile ->
-                if (idToken != null && profile != null) {
-                    picLogin(idToken, profile)
+                if (idToken != null && profile?.nickname != null && profile.profileImageUrl != null) {
+                    picLogin(
+                        idToken = idToken,
+                        nickname = profile.nickname!!,
+                        profileImage = profile.profileImageUrl!!,
+                    )
+                } else {
+                    Log.d(TAG, "정보 조회 실패")
                 }
             },
             onFailure = {
@@ -33,11 +38,11 @@ class LoginViewModel @Inject constructor(
         )
     }
 
-    private fun picLogin(idToken: String, profile: Profile) {
+    private fun picLogin(idToken: String, nickname: String, profileImage: String) {
         val param = LoginParam(
             idToken = idToken,
-            nickname = profile.nickname!!,
-            profileImage = profile.profileImageUrl!!,
+            nickname = nickname,
+            profileImage = profileImage,
         )
         viewModelScope.launch {
             loginUseCase(param)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = java.net.URI("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
 


### PR DESCRIPTION
## Issue No
- close #17 

## Overview (Required)
- UI 작업 XXXX
- 카카오 로그인 SDK 설정 
  - local.properties 에 kakao_native_app_key 설정이랑 키해시 등록 필요해!!
- 네트워크 모듈 설정
- 카카오 로그인 성공 시, 닉네임, 프로필 이미지와 함께 서비스 서버 로그인 (현재는 임시 서버)
- Encrypted Shared Preferences 기본 셋팅 및 토큰 저장

## Links
- [API 스펙](https://www.notion.so/4df39fcc912a4ce8a687a6b0a96cb958)

[고민되는 부분](https://www.notion.so/f281aefc54024923a71720628c940952?pvs=4)이 있는데 이거 계속 고민하다가는 개발 안 끝날 것 같아서 일단 올렸어 같이 고민해주라.. 
