### PR TITLE
:construction_worker: #23 ci 빌드를 위한 secrets 세팅

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
+    # ci 빌드를 위한 secrets 세팅
+    - name: Access github actions secrets
+      env:
+        KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+      run: |
+        echo kakao_native_app_key="$KAKAO_NATIVE_APP_KEY" > ./local.properties
+
     # ktlint
     - name: Check ktlint
       run: ./gradlew ktlintCheck


### PR DESCRIPTION
## Issue No
- close #23 

## Overview (Required)
- github actions에 kakao native app key를 secrets로 세팅해 ci 빌드 시 값을 가져올 수 있도록 구현
