### PR TITLE
[#33] 스낵바 컴포넌트 구현, 로그인 실패 시 스낵바 출력

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/theme/Color.kt
@@ -25,3 +25,5 @@ val Alert = Color(0xFFFF5252)
 // Kakao
 val KakaoPrimaryColor = Color(0xFFFEE500)
 val KakaoOnPrimaryColor = Color(0xFF121212)
+
+val BlackAlpha50 = Color(0x80000000)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/theme/Theme.kt
@@ -60,7 +60,7 @@ fun SharedAlbumTheme(
         SideEffect {
             val window = (view.context as Activity).window
             window.statusBarColor = Gray0.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = true
         }
     }
     MaterialTheme(

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.SnackbarDuration
@@ -75,6 +76,9 @@ private fun PicSnackbar(
             Spacer(modifier = Modifier.width(16.dp))
         }
         Text(
+            modifier = Modifier
+                .wrapContentHeight()
+                .padding(vertical = 2.dp),
             text = message,
             color = Gray0,
             style = PicTypography.bodyMedium16,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -57,10 +57,12 @@ fun PicSnackbarHost(
         modifier = Modifier.padding(bottom = snackbarPosition),
         hostState = state,
     ) { data ->
-        PicSnackbar(
-            type = PicSnackbarType.find(data.visuals.actionLabel),
-            message = data.visuals.message,
-        )
+        with(data.visuals) {
+            PicSnackbar(
+                type = PicSnackbarType.find(actionLabel),
+                message = message,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -24,6 +24,21 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 
+enum class PicSnackbarType(
+    @DrawableRes val iconResId: Int? = null,
+) {
+    NORMAL,
+    CHECK(iconResId = R.drawable.ic_check),
+    WARNING(iconResId = R.drawable.ic_warning),
+    ;
+
+    companion object {
+        fun find(key: String?): PicSnackbarType {
+            return entries.associateBy(PicSnackbarType::name)[key] ?: NORMAL
+        }
+    }
+}
+
 @Composable
 fun PicSnackbar(
     @DrawableRes iconResId: Int? = null,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -56,7 +56,7 @@ fun PicSnackbarHost(
 }
 
 @Composable
-fun PicSnackbar(
+private fun PicSnackbar(
     type: PicSnackbarType = PicSnackbarType.NORMAL,
     message: String,
 ) {
@@ -89,7 +89,7 @@ fun PicSnackbar(
 
 @Preview
 @Composable
-fun PickSnackbarPreView() {
+private fun PickSnackbarPreView() {
     SharedAlbumTheme {
         PicSnackbar(
             type = PicSnackbarType.WARNING,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -62,7 +62,7 @@ private fun PicSnackbar(
             .wrapContentSize()
             .padding(
                 horizontal = 24.dp,
-                vertical = 20.dp,
+                vertical = 16.dp,
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -57,7 +58,7 @@ fun PicSnackbarHost(
 
 @Composable
 private fun PicSnackbar(
-    type: PicSnackbarType = PicSnackbarType.NORMAL,
+    type: PicSnackbarType,
     message: String,
 ) {
     Row(
@@ -85,6 +86,17 @@ private fun PicSnackbar(
             style = PicTypography.bodyMedium16,
         )
     }
+}
+
+suspend fun SnackbarHostState.showPicSnackbar(
+    type: PicSnackbarType = PicSnackbarType.NORMAL,
+    message: String,
+) {
+    showSnackbar(
+        message = message,
+        actionLabel = type.name,
+        duration = SnackbarDuration.Short,
+    )
 }
 
 @Preview

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -15,9 +15,11 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -46,7 +48,13 @@ enum class PicSnackbarType(
 fun PicSnackbarHost(
     state: SnackbarHostState,
 ) {
+    val configuration = LocalConfiguration.current
+    val snackbarPosition = remember(configuration) {
+        (configuration.screenHeightDp - 80).dp
+    }
+
     SnackbarHost(
+        modifier = Modifier.padding(bottom = snackbarPosition),
         hostState = state,
     ) { data ->
         PicSnackbar(

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -89,7 +89,7 @@ private fun PicSnackbar(
 
 @Preview
 @Composable
-private fun PickSnackbarPreView() {
+private fun PicSnackbarPreview() {
     SharedAlbumTheme {
         PicSnackbar(
             type = PicSnackbarType.WARNING,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -1,0 +1,68 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.BlackAlpha50
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+
+@Composable
+fun PicSnackbar(
+    @DrawableRes iconResId: Int? = null,
+    message: String,
+) {
+    Row(
+        modifier = Modifier
+            .clip(shape = RoundedCornerShape(30.dp))
+            .background(color = BlackAlpha50)
+            .wrapContentSize()
+            .padding(
+                horizontal = 24.dp,
+                vertical = 20.dp,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (iconResId != null) {
+            Image(
+                modifier = Modifier.size(20.dp),
+                painter = painterResource(id = iconResId),
+                contentDescription = "snackbar icon",
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+        }
+        Text(
+            text = message,
+            color = Gray0,
+            style = PicTypography.bodyMedium16,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PickSnackbarPreView() {
+    SharedAlbumTheme {
+        PicSnackbar(
+            iconResId = R.drawable.ic_warning,
+            message = "로그인에 실패했어요.",
+        )
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -1,6 +1,5 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 
-import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
@@ -23,26 +22,11 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.BlackAlpha50
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
-
-enum class PicSnackbarType(
-    @DrawableRes val iconResId: Int? = null,
-) {
-    NORMAL,
-    CHECK(iconResId = R.drawable.ic_check),
-    WARNING(iconResId = R.drawable.ic_warning),
-    ;
-
-    companion object {
-        fun find(key: String?): PicSnackbarType {
-            return entries.associateBy(PicSnackbarType::name)[key] ?: NORMAL
-        }
-    }
-}
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 
 @Composable
 fun PicSnackbarHost(

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -36,6 +38,20 @@ enum class PicSnackbarType(
         fun find(key: String?): PicSnackbarType {
             return entries.associateBy(PicSnackbarType::name)[key] ?: NORMAL
         }
+    }
+}
+
+@Composable
+fun PicSnackbarHost(
+    state: SnackbarHostState,
+) {
+    SnackbarHost(
+        hostState = state,
+    ) { data ->
+        PicSnackbar(
+            type = PicSnackbarType.find(data.visuals.actionLabel),
+            message = data.visuals.message,
+        )
     }
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicSnackbar.kt
@@ -41,7 +41,7 @@ enum class PicSnackbarType(
 
 @Composable
 fun PicSnackbar(
-    @DrawableRes iconResId: Int? = null,
+    type: PicSnackbarType = PicSnackbarType.NORMAL,
     message: String,
 ) {
     Row(
@@ -55,10 +55,10 @@ fun PicSnackbar(
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (iconResId != null) {
+        if (type.iconResId != null) {
             Image(
                 modifier = Modifier.size(20.dp),
-                painter = painterResource(id = iconResId),
+                painter = painterResource(id = type.iconResId),
                 contentDescription = "snackbar icon",
             )
             Spacer(modifier = Modifier.width(16.dp))
@@ -76,7 +76,7 @@ fun PicSnackbar(
 fun PickSnackbarPreView() {
     SharedAlbumTheme {
         PicSnackbar(
-            iconResId = R.drawable.ic_warning,
+            type = PicSnackbarType.WARNING,
             message = "로그인에 실패했어요.",
         )
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/model/PicSnackbarType.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/model/PicSnackbarType.kt
@@ -1,0 +1,19 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model
+
+import androidx.annotation.DrawableRes
+import com.mashup.gabbangzip.sharedalbum.presentation.R
+
+enum class PicSnackbarType(
+    @DrawableRes val iconResId: Int? = null,
+) {
+    NORMAL,
+    CHECK(iconResId = R.drawable.ic_check),
+    WARNING(iconResId = R.drawable.ic_warning),
+    ;
+
+    companion object {
+        fun find(key: String?): PicSnackbarType {
+            return entries.associateBy(PicSnackbarType::name)[key] ?: NORMAL
+        }
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
@@ -4,14 +4,23 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarHost
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarType
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.showPicSnackbar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -23,21 +32,31 @@ class LoginActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             val state by viewModel.uiState.collectAsStateWithLifecycle()
+            val snackbarHostState = remember { SnackbarHostState() }
 
             SharedAlbumTheme {
-                LoginScreen(
-                    onClickLoginButton = {
-                        viewModel.login()
+                Scaffold(
+                    snackbarHost = {
+                        PicSnackbarHost(state = snackbarHostState)
                     },
-                )
+                ) { contentPadding ->
+                    Box(modifier = Modifier.padding(contentPadding)) {
+                        LoginScreen(
+                            onClickLoginButton = {
+                                viewModel.login()
+                            },
+                        )
+                    }
+                }
 
                 if (state.errorMessage != null) {
                     Log.d(TAG, "${state.errorMessage}")
-                    Toast.makeText(
-                        this,
-                        getString(R.string.login_failure_message),
-                        Toast.LENGTH_SHORT,
-                    ).show()
+                    LaunchedEffect(snackbarHostState) {
+                        snackbarHostState.showPicSnackbar(
+                            type = PicSnackbarType.WARNING,
+                            message = getString(R.string.login_failure_message),
+                        )
+                    }
                 }
 
                 if (state.isUserLoggedIn) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
@@ -19,7 +19,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarHost
-import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarType
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.showPicSnackbar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
@@ -42,9 +42,7 @@ class LoginActivity : ComponentActivity() {
                 ) { contentPadding ->
                     Box(modifier = Modifier.padding(contentPadding)) {
                         LoginScreen(
-                            onClickLoginButton = {
-                                viewModel.login()
-                            },
+                            onClickLoginButton = viewModel::login,
                         )
                     }
                 }

--- a/presentation/src/main/res/drawable/ic_check.xml
+++ b/presentation/src/main/res/drawable/ic_check.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10,10m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+      android:fillColor="#6EBAFF"/>
+  <path
+      android:pathData="M5,9.5L7.793,12.293C8.183,12.683 8.817,12.683 9.207,12.293L14.5,7"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_warning.xml
+++ b/presentation/src/main/res/drawable/ic_warning.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M10,10m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0"
+      android:fillColor="#FFBD6E"/>
+  <path
+      android:pathData="M10,4.643m-1,0a1,1 0,1 1,2 0a1,1 0,1 1,-2 0"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M10,7.643L10,7.643A1,1 0,0 1,11 8.643L11,14.643A1,1 0,0 1,10 15.643L10,15.643A1,1 0,0 1,9 14.643L9,8.643A1,1 0,0 1,10 7.643z"
+      android:fillColor="#ffffff"/>
+</vector>


### PR DESCRIPTION
## Issue No
- close #33

## Overview (Required)
- 스낵바 컴포넌트 구현
- 로그인 실패 시 스낵바 출력

- 스낵바가 생각보다 화면에서 사용하기가 너무 불편하더라고..? Scaffold도 써야하고 메시지 외에 부가적인 데이터를 넘기는 방법이 안 보여서 actionLabel은 이렇게 쓰라고 있는게 아닌 것 같지만 actionLabel에 type.name 찾아서 아이콘 설정하게끔 구현해두었엉
- 마침 임시서버가 닫혀서 테스트하기 좋더라..?

## Screenshot
[Screen_recording_20240626_000911.webm](https://github.com/mash-up-kr/gabbangzip-Android/assets/78132126/3adcb6b8-b7ec-416f-ba1d-6b4d7911a40c)