### PR TITLE
[#45] 토큰 리프레시

### DIFF
--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/NetworkModule.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/NetworkModule.kt
@@ -1,12 +1,17 @@
 package com.mashup.gabbangzip.sharedalbum.data.di
 
 import com.mashup.gabbangzip.sharedalbum.data.BuildConfig
+import com.mashup.gabbangzip.sharedalbum.data.di.qualifier.AuthClient
+import com.mashup.gabbangzip.sharedalbum.data.di.qualifier.AuthRetrofit
+import com.mashup.gabbangzip.sharedalbum.data.di.qualifier.DefaultClient
+import com.mashup.gabbangzip.sharedalbum.data.di.qualifier.DefaultRetrofit
 import com.mashup.gabbangzip.sharedalbum.data.interceptor.AuthInterceptor
 import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Authenticator
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -29,31 +34,61 @@ internal class NetworkModule {
         }
     }
 
+    @DefaultClient
     @Singleton
     @Provides
-    fun provideOkHttpClient(
+    fun provideDefaultOkHttpClient(
         httpLoggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
+        tokenAuthenticator: Authenticator,
     ): OkHttpClient {
         return OkHttpClient
             .Builder()
             .addInterceptor(httpLoggingInterceptor)
             .addInterceptor(authInterceptor)
+            .authenticator(tokenAuthenticator)
             .build()
     }
 
+    @AuthClient
     @Singleton
     @Provides
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit =
-        Retrofit.Builder()
-            .baseUrl(BASE_URL)
-            .client(okHttpClient)
-            .addConverterFactory(MoshiConverterFactory.create())
+    fun provideAuthOkHttpClient(
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient {
+        return OkHttpClient
+            .Builder()
+            .addInterceptor(httpLoggingInterceptor)
             .build()
+    }
+
+    @DefaultRetrofit
+    @Singleton
+    @Provides
+    fun provideDefaultRetrofit(
+        @DefaultClient okHttpClient: OkHttpClient,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(MoshiConverterFactory.create())
+        .build()
+
+    @AuthRetrofit
+    @Singleton
+    @Provides
+    fun provideAuthRetrofit(
+        @AuthClient okHttpClient: OkHttpClient,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(okHttpClient)
+        .addConverterFactory(MoshiConverterFactory.create())
+        .build()
 
     @Singleton
     @Provides
-    fun provideLoginService(retrofit: Retrofit): LoginService = retrofit.create()
+    fun provideLoginService(
+        @AuthRetrofit retrofit: Retrofit,
+    ): LoginService = retrofit.create()
 
     companion object {
         private const val BASE_URL = "http://ec2-43-203-14-157.ap-northeast-2.compute.amazonaws.com"

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/qualifier/NetworkQualifier.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/di/qualifier/NetworkQualifier.kt
@@ -1,0 +1,19 @@
+package com.mashup.gabbangzip.sharedalbum.data.di.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthRetrofit

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/request/TokenRefreshRequest.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/request/TokenRefreshRequest.kt
@@ -1,0 +1,10 @@
+package com.mashup.gabbangzip.sharedalbum.data.dto.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class TokenRefreshRequest(
+    @Json(name = "refresh_token")
+    val refreshToken: String,
+)

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/TokenRefreshResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/TokenRefreshResponse.kt
@@ -1,0 +1,12 @@
+package com.mashup.gabbangzip.sharedalbum.data.dto.response
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class TokenRefreshResponse(
+    @Json(name = "access_token")
+    val accessToken: String,
+    @Json(name = "refresh_token")
+    val refreshToken: String,
+)

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/interceptor/TokenAuthenticator.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/interceptor/TokenAuthenticator.kt
@@ -1,0 +1,42 @@
+package com.mashup.gabbangzip.sharedalbum.data.interceptor
+
+import com.mashup.gabbangzip.sharedalbum.domain.base.PicException.LoginRequiredException
+import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
+import com.mashup.gabbangzip.sharedalbum.domain.repository.LoginRepository
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class TokenAuthenticator @Inject constructor(
+    private val localDataSource: LocalDataSource,
+    private val loginRepository: LoginRepository,
+) : Authenticator {
+    override fun authenticate(route: Route?, response: Response): Request? {
+        if (response.code == 401) {
+            val refreshToken = localDataSource.getRefreshToken() ?: return null
+            localDataSource.removeToken()
+            val newToken = generateNewAccessToken(refreshToken) ?: return null
+            return response.request.newBuilder().apply {
+                removeHeader("Authorization")
+                addHeader("Authorization", "Bearer $newToken")
+            }.build()
+        }
+        return null
+    }
+
+    private fun generateNewAccessToken(refreshToken: String): String? {
+        return runCatching {
+            runBlocking {
+                loginRepository.generateNewAccessToken(refreshToken)
+                localDataSource.getAccessToken()
+            }
+        }.onFailure {
+            throw LoginRequiredException
+        }.getOrThrow()
+    }
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/LoginRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.data.repository
 
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
+import com.mashup.gabbangzip.sharedalbum.data.dto.request.TokenRefreshRequest
 import com.mashup.gabbangzip.sharedalbum.data.service.LoginService
 import com.mashup.gabbangzip.sharedalbum.domain.datasource.LocalDataSource
 import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
@@ -39,5 +40,21 @@ class LoginRepositoryImpl @Inject constructor(
 
     override fun isUserLoggedIn(): Boolean {
         return localDataSource.getAccessToken()?.isNotBlank() ?: false
+    }
+
+    override suspend fun generateNewAccessToken(refreshToken: String) {
+        val request = TokenRefreshRequest(
+            refreshToken = refreshToken,
+        )
+        runCatching {
+            loginService.getNewAccessToken(request)
+        }.onSuccess { response ->
+            response.data?.run {
+                saveToken(
+                    accessToken = accessToken,
+                    refreshToken = refreshToken,
+                )
+            } ?: throw IllegalStateException("데이터 없음")
+        }.getOrThrow()
     }
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/service/LoginService.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/service/LoginService.kt
@@ -2,7 +2,9 @@ package com.mashup.gabbangzip.sharedalbum.data.service
 
 import com.mashup.gabbangzip.sharedalbum.data.base.PicResponse
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.LoginRequest
+import com.mashup.gabbangzip.sharedalbum.data.dto.request.TokenRefreshRequest
 import com.mashup.gabbangzip.sharedalbum.data.dto.response.LoginResponse
+import com.mashup.gabbangzip.sharedalbum.data.dto.response.TokenRefreshResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -11,4 +13,9 @@ interface LoginService {
     suspend fun login(
         @Body loginRequest: LoginRequest,
     ): PicResponse<LoginResponse>
+
+    @POST("/api/v1/auth/token")
+    suspend fun getNewAccessToken(
+        @Body request: TokenRefreshRequest,
+    ): PicResponse<TokenRefreshResponse>
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/base/PicException.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/base/PicException.kt
@@ -1,0 +1,6 @@
+package com.mashup.gabbangzip.sharedalbum.domain.base
+
+sealed class PicException : Throwable() {
+    data object LoginRequiredException : PicException()
+    data object UnknownException : PicException()
+}

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/repository/LoginRepository.kt
@@ -6,4 +6,5 @@ interface LoginRepository {
     suspend fun login(param: LoginParam)
     fun saveToken(accessToken: String, refreshToken: String)
     fun isUserLoggedIn(): Boolean
+    suspend fun generateNewAccessToken(refreshToken: String)
 }


### PR DESCRIPTION
## Issue No
- close #45 

## Overview (Required)
- 401 에러 발생 시 토큰 리프레시 후 재요청
- 리프레시 실패 시 LoginRequiredException
- 무한 루프 방지를 위해 토큰 리프레시 필요 여부에 따라 주입하는 네트워크 객체 분리