### PR TITLE
[#86] API 호출 간소화

### DIFF
--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
@@ -20,3 +20,9 @@ data class PicErrorResponse(
     @Json(name = "message")
     val message: String,
 )
+
+suspend fun <T> callApi(
+    execute: suspend () -> PicResponse<T>,
+): T {
+    return execute().data ?: throw IllegalStateException()
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.data.repository
 
+import com.mashup.gabbangzip.sharedalbum.data.base.callApi
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.CreateGroupRequest
 import com.mashup.gabbangzip.sharedalbum.data.service.GroupService
 import com.mashup.gabbangzip.sharedalbum.domain.model.GroupInfo
@@ -16,7 +17,8 @@ class GroupRepositoryImpl @Inject constructor(
             keyword = groupParam.keyword,
             groupImageUrl = groupParam.groupImageUrl,
         )
-        return groupService.createGroup(request).data?.run {
+        val response = callApi { groupService.createGroup(request) }
+        return response.run {
             GroupInfo(
                 id = id,
                 groupName = groupName,
@@ -24,6 +26,6 @@ class GroupRepositoryImpl @Inject constructor(
                 groupImageUrl = groupImageUrl,
                 groupInvitationUrl = groupInvitationUrl,
             )
-        } ?: throw IllegalStateException("데이터 없음")
+        }
     }
 }


### PR DESCRIPTION
## Issue No
- close #86 

## Overview (Required)
- PicResponse에서 data 만 꺼내주는 메서드를 하나 만들었는데 별 내용 없어유,, ㅎ
- 원래는 에러 핸들러를 만들어볼까 하다가 정우오빠가 전에 했던 말처럼 우리가 커스텀 에러코드를 받긴하지만 당장 사용할 필요는 없어보여서 그냥 성공하면 data만 꺼내주고, 실패하면 예외 던지게끔만 해놨슴다. null 처리는 귀찮으니까.