### PR TITLE
[#93] 더블클릭 방지 코드 추가 및 적용

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/ModifierExt.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/ModifierExt.kt
@@ -1,7 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.utils
 
 import androidx.compose.foundation.Indication
-import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/ModifierExt.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/ModifierExt.kt
@@ -45,27 +45,7 @@ fun Modifier.noRippleClickable(
     )
 }
 
-fun Modifier.singleClickable(
-    onClick: () -> Unit,
-    enabled: Boolean = true,
-    onClickLabel: String? = null,
-    role: Role? = null,
-    debounceMillis: Long = 300L,
-): Modifier = composed {
-    multipleEventsCutter(debounceMillis = debounceMillis) { manager ->
-        this then singleClickable(
-            interactionSource = remember { MutableInteractionSource() },
-            indication = LocalIndication.current,
-            onClick = { manager.processEvent { onClick() } },
-            enabled = enabled,
-            onClickLabel = onClickLabel,
-            role = role,
-            debounceMillis = debounceMillis,
-        )
-    }
-}
-
-fun Modifier.singleClickable(
+private fun Modifier.singleClickable(
     interactionSource: MutableInteractionSource,
     indication: Indication?,
     onClick: () -> Unit,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/ModifierExt.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/ModifierExt.kt
@@ -1,5 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.utils
 
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -17,7 +19,7 @@ fun Modifier.rippleClickable(
     role: Role? = null,
     onClick: () -> Unit,
 ): Modifier = composed {
-    this then clickable(
+    this then singleClickable(
         interactionSource = remember { MutableInteractionSource() },
         indication = rememberRipple(),
         enabled = enabled,
@@ -33,7 +35,7 @@ fun Modifier.noRippleClickable(
     role: Role? = null,
     onClick: () -> Unit,
 ): Modifier = composed {
-    this then clickable(
+    this then singleClickable(
         interactionSource = remember { MutableInteractionSource() },
         indication = null,
         enabled = enabled,
@@ -41,6 +43,47 @@ fun Modifier.noRippleClickable(
         role = role,
         onClick = onClick,
     )
+}
+
+fun Modifier.singleClickable(
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    debounceMillis: Long = 300L,
+): Modifier = composed {
+    multipleEventsCutter(debounceMillis = debounceMillis) { manager ->
+        this then singleClickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = LocalIndication.current,
+            onClick = { manager.processEvent { onClick() } },
+            enabled = enabled,
+            onClickLabel = onClickLabel,
+            role = role,
+            debounceMillis = debounceMillis,
+        )
+    }
+}
+
+fun Modifier.singleClickable(
+    interactionSource: MutableInteractionSource,
+    indication: Indication?,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    debounceMillis: Long = 300L,
+): Modifier = composed {
+    multipleEventsCutter(debounceMillis = debounceMillis) { manager ->
+        this then clickable(
+            interactionSource = interactionSource,
+            indication = indication,
+            enabled = enabled,
+            onClickLabel = onClickLabel,
+            role = role,
+            onClick = { manager.processEvent { onClick() } },
+        )
+    }
 }
 
 fun Modifier.hideKeyboardOnOutsideClicked(): Modifier = composed {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/MultipleEventsCutterManager.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/MultipleEventsCutterManager.kt
@@ -1,0 +1,50 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+
+/***
+ * onClick 중복 클릭 방지를 위한 코드
+ * @see (https://al-e-shevelev.medium.com/how-to-prevent-multiple-clicks-in-android-jetpack-compose-8e62224c9c5e)[link]
+ */
+interface MultipleEventsCutterManager {
+    fun processEvent(event: () -> Unit)
+}
+
+@OptIn(FlowPreview::class)
+@Composable
+fun <T> multipleEventsCutter(
+    debounceMillis: Long = 300L,
+    content: @Composable (MultipleEventsCutterManager) -> T,
+): T {
+    val debounceState = remember {
+        MutableSharedFlow<() -> Unit>(
+            replay = 0,
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+    }
+
+    val result = content(
+        object : MultipleEventsCutterManager {
+            override fun processEvent(event: () -> Unit) {
+                debounceState.tryEmit(event)
+            }
+        },
+    )
+
+    LaunchedEffect(true) {
+        debounceState
+            .debounce(debounceMillis)
+            .collect { onClick ->
+                onClick.invoke()
+            }
+    }
+
+    return result
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/MultipleEventsCutterManager.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/MultipleEventsCutterManager.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.debounce
 
 /***
- * onClick 중복 클릭 방지를 위한 코드
+ * onClick 중복 클릭 방지를 위한 지연 실행 Manager
  * @see (https://al-e-shevelev.medium.com/how-to-prevent-multiple-clicks-in-android-jetpack-compose-8e62224c9c5e)[link]
  */
 interface MultipleEventsCutterManager {


### PR DESCRIPTION
## Issue No
- close #93 

## Overview (Required)
- 더블클릭 방지 코드 추가 및 적용
- Flow 의 debounce 기능을 이용해서 적용한 케이스가 있던데 이 코드를 그대로 적용해보는 것은 어떨까싶어 가져와보았어요~

## Links
- https://al-e-shevelev.medium.com/how-to-prevent-multiple-clicks-in-android-jetpack-compose-8e62224c9c5e
