### PR TITLE
[#80][#81] 갤러리 컴포넌트 및 날짜 선택 필드 구현

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicDatePickerField.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicDatePickerField.kt
@@ -1,0 +1,56 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
+
+@Composable
+fun PicDatePickerField(
+    modifier: Modifier = Modifier,
+    date: String = "",
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Gray40)
+            .padding(horizontal = 16.dp, vertical = 18.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        StableImage(
+            drawableResId = R.drawable.ic_calender,
+            contentDescription = stringResource(id = R.string.pic_calendar),
+        )
+        Text(
+            text = date.ifEmpty { stringResource(id = R.string.pic_date_default) },
+            style = PicTypography.bodyMedium16,
+            color = if (date.isEmpty()) Gray60 else Gray80,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PicDatePickerFieldPreview() {
+    PicDatePickerField(
+        modifier = Modifier.fillMaxWidth(),
+        date = "24/10/26",
+    )
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicDatePickerField.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicDatePickerField.kt
@@ -1,6 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,7 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.gabbangzip.sharedalbum.presentation.R
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray20
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
@@ -29,7 +30,12 @@ fun PicDatePickerField(
     Row(
         modifier = modifier
             .clip(RoundedCornerShape(8.dp))
-            .background(Gray40)
+            .background(Gray20)
+            .border(
+                width = 1.dp,
+                color = Gray20,
+                shape = RoundedCornerShape(8.dp),
+            )
             .padding(horizontal = 16.dp, vertical = 18.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicGallery.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicGallery.kt
@@ -1,0 +1,63 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
+
+@Composable
+fun PicGallery(
+    modifier: Modifier = Modifier,
+    currentCount: Int = 0,
+    totalCount: Int = 4,
+) {
+    Column(
+        modifier = modifier
+            .size(100.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(Gray40)
+            .padding(horizontal = 36.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        StableImage(
+            drawableResId = R.drawable.ic_gallery,
+            contentDescription = stringResource(id = R.string.pic_gallery),
+        )
+        Text(
+            text = buildAnnotatedString {
+                withStyle(style = SpanStyle(color = if (currentCount > 0) Gray80 else Gray60)) {
+                    append(currentCount.toString())
+                }
+                append("/$totalCount")
+            },
+            style = PicTypography.bodyMedium16,
+            color = Gray60,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PicGalleryPreview() {
+    PicGallery()
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicGallery.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicGallery.kt
@@ -1,6 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -18,7 +19,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.gabbangzip.sharedalbum.presentation.R
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray20
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray50
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
@@ -34,7 +36,12 @@ fun PicGallery(
         modifier = modifier
             .size(100.dp)
             .clip(RoundedCornerShape(10.dp))
-            .background(Gray40)
+            .background(Gray20)
+            .border(
+                width = 1.dp,
+                color = Gray50,
+                shape = RoundedCornerShape(10.dp),
+            )
             .padding(horizontal = 36.dp, vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTextField.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTextField.kt
@@ -1,6 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,15 +15,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.Cultured
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray20
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray50
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.SilverSand
 
 @Composable
 fun PicTextField(
@@ -34,8 +37,11 @@ fun PicTextField(
 ) {
     BasicTextField(
         modifier = modifier
-            .background(
-                color = Cultured,
+            .clip(RoundedCornerShape(10.dp))
+            .background(Gray20)
+            .border(
+                width = 1.dp,
+                color = Gray50,
                 shape = RoundedCornerShape(10.dp),
             )
             .padding(horizontal = 20.dp, vertical = 18.dp),
@@ -56,7 +62,7 @@ fun PicTextField(
                 Text(
                     text = hint,
                     style = PicTypography.bodyMedium16,
-                    color = SilverSand,
+                    color = Gray60,
                 )
             }
             innerTextField()
@@ -71,7 +77,9 @@ fun PicTextFieldPreview() {
         Column(modifier = Modifier.background(Gray80)) {
             var text by remember { mutableStateOf("") }
             PicTextField(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
                 value = text,
                 onValueChange = { text = it },
                 hint = "최대 10자 까지 입력 가능해요.",

--- a/presentation/src/main/res/drawable/ic_calender.xml
+++ b/presentation/src/main/res/drawable/ic_calender.xml
@@ -1,0 +1,29 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="20"
+    android:viewportHeight="20">
+  <path
+      android:pathData="M16.564,4.903L3.571,4.903C3.054,4.903 2.635,5.318 2.635,5.829L2.635,15.74C2.635,16.252 3.054,16.666 3.571,16.666H16.564C17.081,16.666 17.5,16.252 17.5,15.74V5.829C17.5,5.318 17.081,4.903 16.564,4.903Z"
+      android:strokeWidth="1.4"
+      android:fillColor="#D9D9D9"
+      android:strokeColor="#D9D9D9"/>
+  <path
+      android:pathData="M3.5,9.422L16.5,9.422"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#F1F1F1"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6.26,2.333L6.26,6.333"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#D9D9D9"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M13.689,2.333V6.333"
+      android:strokeWidth="1.4"
+      android:fillColor="#00000000"
+      android:strokeColor="#D9D9D9"
+      android:strokeLineCap="round"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_gallery.xml
+++ b/presentation/src/main/res/drawable/ic_gallery.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M8,0L20,0A8,8 0,0 1,28 8L28,20A8,8 0,0 1,20 28L8,28A8,8 0,0 1,0 20L0,8A8,8 0,0 1,8 0z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M18.666,8.556m-2.333,0a2.333,2.333 0,1 1,4.667 0a2.333,2.333 0,1 1,-4.667 0"
+      android:fillColor="#D9D9D9"/>
+  <group>
+    <clip-path
+        android:pathData="M8,0L20,0A8,8 0,0 1,28 8L28,20A8,8 0,0 1,20 28L8,28A8,8 0,0 1,0 20L0,8A8,8 0,0 1,8 0z"/>
+    <path
+        android:pathData="M22.167,32.667C18.077,32.667 12.228,32.174 8.161,32.605C7.78,32.646 7.392,32.667 7,32.667C0.986,32.667 -3.889,27.791 -3.889,21.778C-3.889,15.764 0.986,10.889 7,10.889C9.785,10.889 12.325,11.934 14.251,13.653C16.222,15.414 19.524,16.333 22.167,16.333C26.677,16.333 30.334,19.99 30.334,24.5C30.334,29.01 26.677,32.667 22.167,32.667Z"
+        android:fillColor="#D9D9D9"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -39,9 +39,11 @@
     <string name="group_creation_name_hint">최대 10자 까지 입력 가능해요.</string>
     <string name="group_creation_keyword_title">그룹의 키워드를 선택해 주세요</string>
 
-    <string name="pic_tag">% 태그 이미지</string>
+    <string name="pic_tag">%s 태그 이미지</string>
     <string name="pic_keyword_button">%s 키워드 버튼 이미지</string>
-    <string name="pic_button">% 버튼 이미지</string>
+    <string name="pic_button">%s 버튼 이미지</string>
+    <string name="pic_calendar">캘린더</string>
+    <string name="pic_date_default">YY/MM/DD</string>
     <string name="group_main_picture">그룹 대표 사진</string>
     <string name="group_symbol">그룹 심볼</string>
     <string name="detail_page_move">상세 페이지 이동</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="pic_button">%s 버튼 이미지</string>
     <string name="pic_calendar">캘린더</string>
     <string name="pic_date_default">YY/MM/DD</string>
+    <string name="pic_gallery">갤러리</string>
     <string name="group_main_picture">그룹 대표 사진</string>
     <string name="group_symbol">그룹 심볼</string>
     <string name="detail_page_move">상세 페이지 이동</string>


### PR DESCRIPTION
## Issue No
- close #80
- close #81 

## Overview (Required)
- 갤러리 컴포넌트 및 날짜 선택 필드 구현


## Screenshot
<img width="480" alt="image" src="https://github.com/mash-up-kr/gabbangzip-Android/assets/51108983/ff45f982-1158-4064-8f0e-2842fe1a4813">

<img width="266" alt="image" src="https://github.com/mash-up-kr/gabbangzip-Android/assets/51108983/0ff992b8-b4aa-4583-93dc-2e2aa5323a3a">
