### PR TITLE
[#11] 그룹 완료화면 UI 디자인 구현

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
@@ -65,7 +65,7 @@ class GroupCreationActivity : ComponentActivity() {
                         updateName = viewModel::updateName,
                         updateKeyword = viewModel::updateKeyword,
                         onNextButtonClicked = { finish() },
-                        showToastMessage = { message -> viewModel.updateToastMessage(message) }
+                        showSnackbarMessage = { message -> viewModel.showSnackbarMessage(message) }
                     )
                 }
             }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
@@ -53,6 +53,8 @@ class GroupCreationActivity : ComponentActivity() {
                         onGetThumbnailButtonClicked = photoPicker::open,
                         updateName = viewModel::updateName,
                         updateKeyword = viewModel::updateKeyword,
+                        onNextButtonClicked = { finish() },
+                        onCopyLinkButton = { }
                     )
                 }
             }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
@@ -65,7 +65,7 @@ class GroupCreationActivity : ComponentActivity() {
                         updateName = viewModel::updateName,
                         updateKeyword = viewModel::updateKeyword,
                         onNextButtonClicked = { finish() },
-                        showSnackbarMessage = { message -> viewModel.showSnackbarMessage(message) }
+                        showSnackbarMessage = { message -> viewModel.showSnackbarMessage(message) },
                     )
                 }
             }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
@@ -13,22 +13,22 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarHost
-import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.showPicSnackbar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.navigation.GroupCreationNavHost
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.navigation.GroupCreationRoute
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.PicPhotoPicker
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class GroupCreationActivity : ComponentActivity() {
@@ -65,21 +65,15 @@ class GroupCreationActivity : ComponentActivity() {
                         updateName = viewModel::updateName,
                         updateKeyword = viewModel::updateKeyword,
                         onNextButtonClicked = { finish() },
-                        showSnackbarMessage = { message -> viewModel.showSnackbarMessage(message) },
+                        showSnackbarMessage = { type, message ->
+                            lifecycleScope.launch {
+                                snackbarHostState.showPicSnackbar(
+                                    type = type,
+                                    message = message,
+                                )
+                            }
+                        },
                     )
-                }
-            }
-
-            LaunchedEffect(true) {
-                viewModel.effect.collect {
-                    when (it) {
-                        is GroupCreationViewModel.Event.ShowToast -> {
-                            snackbarHostState.showPicSnackbar(
-                                type = PicSnackbarType.CHECK,
-                                message = it.message,
-                            )
-                        }
-                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
@@ -6,11 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.CreateGroupUseCase
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -21,12 +18,6 @@ class GroupCreationViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(GroupCreationState())
     val uiState: StateFlow<GroupCreationState> = _uiState.asStateFlow()
-
-    private val _effect = MutableSharedFlow<Event>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-    val effect = _effect.asSharedFlow()
 
     fun updateName(name: String) {
         viewModelScope.launch {
@@ -47,13 +38,6 @@ class GroupCreationViewModel @Inject constructor(
             }
         }
     }
-
-    fun showSnackbarMessage(toastMessage: String) {
-        viewModelScope.launch {
-            _effect.emit(Event.ShowToast(message = toastMessage))
-        }
-    }
-
     fun createGroup() {
         viewModelScope.launch {
             val currentState = uiState.value
@@ -66,9 +50,5 @@ class GroupCreationViewModel @Inject constructor(
 //                )
 //            )
         }
-    }
-
-    sealed interface Event {
-        class ShowToast(val message: String) : Event
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
@@ -4,7 +4,6 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.CreateGroupUseCase
-import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -49,7 +48,7 @@ class GroupCreationViewModel @Inject constructor(
         }
     }
 
-    fun updateToastMessage(toastMessage: String) {
+    fun showSnackbarMessage(toastMessage: String) {
         viewModelScope.launch {
             _effect.emit(Event.ShowToast(message = toastMessage))
         }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
@@ -4,10 +4,14 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.CreateGroupUseCase
+import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -18,6 +22,12 @@ class GroupCreationViewModel @Inject constructor(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(GroupCreationState())
     val uiState: StateFlow<GroupCreationState> = _uiState.asStateFlow()
+
+    private val _effect = MutableSharedFlow<Event>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val effect = _effect.asSharedFlow()
 
     fun updateName(name: String) {
         viewModelScope.launch {
@@ -39,6 +49,12 @@ class GroupCreationViewModel @Inject constructor(
         }
     }
 
+    fun updateToastMessage(toastMessage: String) {
+        viewModelScope.launch {
+            _effect.emit(Event.ShowToast(message = toastMessage))
+        }
+    }
+
     fun createGroup() {
         viewModelScope.launch {
             val currentState = uiState.value
@@ -51,5 +67,9 @@ class GroupCreationViewModel @Inject constructor(
 //                )
 //            )
         }
+    }
+
+    sealed interface Event {
+        class ShowToast(val message: String) : Event
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -111,6 +111,6 @@ fun GroupCreationCompleteScreen(
 private fun GroupCreationCompleteScreenPreview() {
     GroupCreationCompleteScreen(
         onNextButtonClicked = { },
-        showSnackbarMessage = { }
+        showSnackbarMessage = { },
     )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -30,8 +32,10 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextOnlyTopBa
 @Composable
 fun GroupCreationCompleteScreen(
     onNextButtonClicked: () -> Unit,
-    onCopyLinkButton: () -> Unit,
+    showToastMessage: (message: String) -> Unit,
 ) {
+    val clipboardManager = LocalClipboardManager.current
+    val copyLinkMessage = stringResource(id = R.string.button_copy_link_message)
     Column {
         PicTextOnlyTopBar(
             modifier = Modifier
@@ -85,7 +89,10 @@ fun GroupCreationCompleteScreen(
                 backgroundColor = Gray40,
                 contentColor = Gray80,
                 iconRes = R.drawable.ic_link,
-                onButtonClicked = onCopyLinkButton,
+                onButtonClicked = {
+                    showToastMessage(copyLinkMessage)
+                    clipboardManager.setText(AnnotatedString("임시 텍스트")) // Todo : API 연결 하면서 업데이트 예정
+                },
             )
         }
         PicButton(
@@ -104,6 +111,6 @@ fun GroupCreationCompleteScreen(
 private fun GroupCreationCompleteScreenPreview() {
     GroupCreationCompleteScreen(
         onNextButtonClicked = { },
-        onCopyLinkButton = { },
+        showToastMessage = { }
     )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -101,7 +101,7 @@ fun GroupCreationCompleteScreen(
 
 @Preview(showBackground = true)
 @Composable
-fun GroupCreationCompleteScreenPreview() {
+private fun GroupCreationCompleteScreenPreview() {
     GroupCreationCompleteScreen(
         onNextButtonClicked = { },
         onCopyLinkButton = { },

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -1,0 +1,107 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0Alpha80
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicButton
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicProgressBar
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextOnlyTopBar
+
+@Composable
+fun GroupCreationCompleteScreen(
+    onNextButtonClicked: () -> Unit,
+    onCopyLinkButton: () -> Unit,
+) {
+    Column {
+        PicTextOnlyTopBar(
+            modifier = Modifier
+                .background(Gray0Alpha80)
+                .padding(top = 21.dp),
+            titleText = "완료",
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            PicProgressBar(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp),
+                level = 4,
+                total = 4f,
+            )
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(bottom = 16.dp),
+                text = "그룹에 친구들을 추가하고\n추억을 함께 PIC 해보세요",
+                style = PicTypography.headBold18,
+                color = Gray80,
+                textAlign = TextAlign.Center,
+            )
+            Box( // Todo : 프레임 카드 만들어넣기
+                modifier = Modifier
+                    .size(310.dp, 420.dp)
+                    .padding(bottom = 16.dp)
+                    .background(Color.Cyan),
+            )
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .padding(bottom = 8.dp),
+                text = "그룹원은 최대 6명까지 초대 가능해요.",
+                style = PicTypography.bodyMedium14,
+                color = Gray60,
+                textAlign = TextAlign.Center,
+            )
+            PicNormalButton(
+                text = "링크 복사",
+                isRippleClickable = true,
+                backgroundColor = Gray40,
+                contentColor = Gray80,
+                iconRes = R.drawable.ic_link,
+                onButtonClicked = onCopyLinkButton,
+            )
+        }
+        PicButton(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
+            text = "완료",
+            isRippleClickable = true,
+            onButtonClicked = onNextButtonClicked,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GroupCreationCompleteScreenPreview() {
+    GroupCreationCompleteScreen(
+        onNextButtonClicked = { },
+        onCopyLinkButton = { },
+    )
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -36,7 +37,7 @@ fun GroupCreationCompleteScreen(
             modifier = Modifier
                 .background(Gray0Alpha80)
                 .padding(top = 21.dp),
-            titleText = "완료",
+            titleText = stringResource(id = R.string.complete),
         )
         Column(
             modifier = Modifier
@@ -56,12 +57,13 @@ fun GroupCreationCompleteScreen(
                     .fillMaxWidth()
                     .wrapContentHeight()
                     .padding(bottom = 16.dp),
-                text = "그룹에 친구들을 추가하고\n추억을 함께 PIC 해보세요",
+                text = stringResource(id = R.string.group_complete_title),
                 style = PicTypography.headBold18,
                 color = Gray80,
                 textAlign = TextAlign.Center,
             )
-            Box( // Todo : 프레임 카드 만들어넣기
+            Box(
+                // Todo : 프레임 카드 만들어넣기
                 modifier = Modifier
                     .size(310.dp, 420.dp)
                     .padding(bottom = 16.dp)
@@ -72,13 +74,13 @@ fun GroupCreationCompleteScreen(
                     .fillMaxWidth()
                     .wrapContentHeight()
                     .padding(bottom = 8.dp),
-                text = "그룹원은 최대 6명까지 초대 가능해요.",
+                text = stringResource(id = R.string.group_complete_contents),
                 style = PicTypography.bodyMedium14,
                 color = Gray60,
                 textAlign = TextAlign.Center,
             )
             PicNormalButton(
-                text = "링크 복사",
+                text = stringResource(id = R.string.button_copy_link),
                 isRippleClickable = true,
                 backgroundColor = Gray40,
                 contentColor = Gray80,
@@ -90,7 +92,7 @@ fun GroupCreationCompleteScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
-            text = "완료",
+            text = stringResource(id = R.string.complete),
             isRippleClickable = true,
             onButtonClicked = onNextButtonClicked,
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -32,7 +32,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextOnlyTopBa
 @Composable
 fun GroupCreationCompleteScreen(
     onNextButtonClicked: () -> Unit,
-    showToastMessage: (message: String) -> Unit,
+    showSnackbarMessage: (message: String) -> Unit,
 ) {
     val clipboardManager = LocalClipboardManager.current
     val copyLinkMessage = stringResource(id = R.string.button_copy_link_message)
@@ -90,7 +90,7 @@ fun GroupCreationCompleteScreen(
                 contentColor = Gray80,
                 iconRes = R.drawable.ic_link,
                 onButtonClicked = {
-                    showToastMessage(copyLinkMessage)
+                    showSnackbarMessage(copyLinkMessage)
                     clipboardManager.setText(AnnotatedString("임시 텍스트")) // Todo : API 연결 하면서 업데이트 예정
                 },
             )
@@ -111,6 +111,6 @@ fun GroupCreationCompleteScreen(
 private fun GroupCreationCompleteScreenPreview() {
     GroupCreationCompleteScreen(
         onNextButtonClicked = { },
-        showToastMessage = { }
+        showSnackbarMessage = { }
     )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -28,11 +28,12 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicProgressBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextOnlyTopBar
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 
 @Composable
 fun GroupCreationCompleteScreen(
     onNextButtonClicked: () -> Unit,
-    showSnackbarMessage: (message: String) -> Unit,
+    showSnackbarMessage: (type: PicSnackbarType, message: String) -> Unit,
 ) {
     val clipboardManager = LocalClipboardManager.current
     val copyLinkMessage = stringResource(id = R.string.button_copy_link_message)
@@ -90,7 +91,7 @@ fun GroupCreationCompleteScreen(
                 contentColor = Gray80,
                 iconRes = R.drawable.ic_link,
                 onButtonClicked = {
-                    showSnackbarMessage(copyLinkMessage)
+                    showSnackbarMessage(PicSnackbarType.CHECK, copyLinkMessage)
                     clipboardManager.setText(AnnotatedString("임시 텍스트")) // Todo : API 연결 하면서 업데이트 예정
                 },
             )
@@ -111,6 +112,6 @@ fun GroupCreationCompleteScreen(
 private fun GroupCreationCompleteScreenPreview() {
     GroupCreationCompleteScreen(
         onNextButtonClicked = { },
-        showSnackbarMessage = { },
+        showSnackbarMessage = { _, _ -> },
     )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
@@ -12,12 +12,12 @@ fun NavController.navigateToGroupCreationComplete() {
 
 fun NavGraphBuilder.groupCreationCompleteNavGraph(
     onNextButtonClicked: () -> Unit,
-    showToastMessage: (message: String) -> Unit,
+    showSnackbarMessage: (message: String) -> Unit,
 ) {
     composable(route = GroupCreationRoute.CompleteScreenRoute.route) {
         GroupCreationCompleteScreen(
             onNextButtonClicked = onNextButtonClicked,
-            showToastMessage = showToastMessage
+            showSnackbarMessage = showSnackbarMessage
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
@@ -12,12 +12,12 @@ fun NavController.navigateToGroupCreationComplete() {
 
 fun NavGraphBuilder.groupCreationCompleteNavGraph(
     onNextButtonClicked: () -> Unit,
-    onCopyLinkButton: () -> Unit,
+    showToastMessage: (message: String) -> Unit,
 ) {
     composable(route = GroupCreationRoute.CompleteScreenRoute.route) {
         GroupCreationCompleteScreen(
             onNextButtonClicked = onNextButtonClicked,
-            onCopyLinkButton = onCopyLinkButton
+            showToastMessage = showToastMessage
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
@@ -1,0 +1,23 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.navigation
+
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.GroupCreationCompleteScreen
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.navigation.GroupCreationRoute
+
+fun NavController.navigateToGroupCreationComplete() {
+    navigate(GroupCreationRoute.CompleteScreenRoute.route)
+}
+
+fun NavGraphBuilder.groupCreationCompleteNavGraph(
+    onNextButtonClicked: () -> Unit,
+    onCopyLinkButton: () -> Unit,
+) {
+    composable(route = GroupCreationRoute.CompleteScreenRoute.route) {
+        GroupCreationCompleteScreen(
+            onNextButtonClicked = onNextButtonClicked,
+            onCopyLinkButton = onCopyLinkButton
+        )
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
@@ -17,7 +17,7 @@ fun NavGraphBuilder.groupCreationCompleteNavGraph(
     composable(route = GroupCreationRoute.CompleteScreenRoute.route) {
         GroupCreationCompleteScreen(
             onNextButtonClicked = onNextButtonClicked,
-            showSnackbarMessage = showSnackbarMessage
+            showSnackbarMessage = showSnackbarMessage,
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
@@ -3,6 +3,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.GroupCreationCompleteScreen
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.navigation.GroupCreationRoute
 
@@ -12,7 +13,7 @@ fun NavController.navigateToGroupCreationComplete() {
 
 fun NavGraphBuilder.groupCreationCompleteNavGraph(
     onNextButtonClicked: () -> Unit,
-    showSnackbarMessage: (message: String) -> Unit,
+    showSnackbarMessage: (type: PicSnackbarType, message: String) -> Unit,
 ) {
     composable(route = GroupCreationRoute.CompleteScreenRoute.route) {
         GroupCreationCompleteScreen(

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
@@ -28,7 +28,7 @@ fun GroupCreationNavHost(
     updateName: (name: String) -> Unit,
     updateKeyword: (keyword: GroupKeyword) -> Unit,
     onNextButtonClicked: () -> Unit,
-    onCopyLinkButton: () -> Unit,
+    showToastMessage: (message: String) -> Unit,
 ) {
     NavHost(
         modifier = modifier,
@@ -64,7 +64,7 @@ fun GroupCreationNavHost(
         )
         groupCreationCompleteNavGraph(
             onNextButtonClicked = onNextButtonClicked,
-            onCopyLinkButton = onCopyLinkButton,
+            showToastMessage = showToastMessage
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
@@ -28,7 +28,7 @@ fun GroupCreationNavHost(
     updateName: (name: String) -> Unit,
     updateKeyword: (keyword: GroupKeyword) -> Unit,
     onNextButtonClicked: () -> Unit,
-    showToastMessage: (message: String) -> Unit,
+    showSnackbarMessage: (message: String) -> Unit,
 ) {
     NavHost(
         modifier = modifier,
@@ -64,7 +64,7 @@ fun GroupCreationNavHost(
         )
         groupCreationCompleteNavGraph(
             onNextButtonClicked = onNextButtonClicked,
-            showToastMessage = showToastMessage
+            showSnackbarMessage = showSnackbarMessage
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.GroupCreationState
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.navigation.groupCreationCompleteNavGraph
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.navigation.navigateToGroupCreationComplete
@@ -28,7 +29,7 @@ fun GroupCreationNavHost(
     updateName: (name: String) -> Unit,
     updateKeyword: (keyword: GroupKeyword) -> Unit,
     onNextButtonClicked: () -> Unit,
-    showSnackbarMessage: (message: String) -> Unit,
+    showSnackbarMessage: (type: PicSnackbarType, message: String) -> Unit,
 ) {
     NavHost(
         modifier = modifier,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
@@ -7,6 +7,8 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.GroupCreationState
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.navigation.groupCreationCompleteNavGraph
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.navigation.navigateToGroupCreationComplete
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.intro.navigation.groupCreationIntroNavGraph
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.keyword.navigation.groupCreationKeywordNavGraph
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.keyword.navigation.navigateToGroupCreationKeyword
@@ -25,6 +27,8 @@ fun GroupCreationNavHost(
     onGetThumbnailButtonClicked: () -> Unit,
     updateName: (name: String) -> Unit,
     updateKeyword: (keyword: GroupKeyword) -> Unit,
+    onNextButtonClicked: () -> Unit,
+    onCopyLinkButton: () -> Unit,
 ) {
     NavHost(
         modifier = modifier,
@@ -55,8 +59,12 @@ fun GroupCreationNavHost(
         groupCreationThumbnailNavGraph(
             initialThumbnail = groupCreationState.thumbnail,
             onBackButtonClicked = { navController.popBackStack() },
-            onNextButtonClicked = { },
+            onNextButtonClicked = { navController.navigateToGroupCreationComplete() },
             onGetThumbnailButtonClicked = onGetThumbnailButtonClicked,
+        )
+        groupCreationCompleteNavGraph(
+            onNextButtonClicked = onNextButtonClicked,
+            onCopyLinkButton = onCopyLinkButton,
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
@@ -64,7 +64,7 @@ fun GroupCreationNavHost(
         )
         groupCreationCompleteNavGraph(
             onNextButtonClicked = onNextButtonClicked,
-            showSnackbarMessage = showSnackbarMessage
+            showSnackbarMessage = showSnackbarMessage,
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationRoute.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationRoute.kt
@@ -19,6 +19,10 @@ sealed interface GroupCreationRoute {
         override val route: String = "groupThumbnailScreenRoute"
     }
 
+    data object CompleteScreenRoute : GroupCreationRoute {
+        override val route: String = "groupCompleteScreenRoute"
+    }
+
     companion object {
         val initRoute = IntroScreenRoute.route
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -70,4 +70,8 @@
     <string name="group_add">이미지 추가</string>
     <string name="group_modify">이미지 수정</string>
     <string name="thumbnail_image">썸네일 이미지</string>
+
+    <string name="complete">완료</string>
+    <string name="group_complete_title">그룹에 친구들을 추가하고\n추억을 함께 PIC 해보세요</string>
+    <string name="group_complete_contents">그룹원은 최대 6명까지 초대 가능해요.</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -65,7 +65,8 @@
     <string name="group_add_more_member">그룹원을 추가하고 싶으세요?</string>
     <string name="group_maximum_count">그룹 최대 인원은 6명이에요.</string>
     <string name="button_copy_link">링크 복사</string>
-    
+    <string name="button_copy_link_message">링크를 복사했어요.</string>
+
     <string name="group_add_description">그룹의 대표 사진을 추가해 주세요</string>
     <string name="group_add">이미지 추가</string>
     <string name="group_modify">이미지 수정</string>


### PR DESCRIPTION
## Issue No
- close #11 

## Overview (Required)
- 그룹 완료하면 UI 디자인 구현
- 링크복사 없어질 수 있는데 추후에 변경되면 따로 이슈 올릴 예정이에요~!
- 그룹 만들기 화면은 Activity 에서 UiState 를 가지고 있는 구조이다보니 Snackbar 노출하는 기능을 별도의 SharedFlow 로 빼주었습니다. 
  => 부연설명 : 다른 화면처럼 state 에 snackbarMessage 같은걸 추가해서 구현하는 방법도 있었지만, 이게 클릭하면 clipboard 에 복붙하고 snackbar 보여줘야하는 로직이라.. 클릭할 때 마다 snackbar 가 노출되게 하려면 버튼 클릭할 때 마다 `uiState.copy(snackbarMessage = null)` `uiState.copy(snackbarMessage = "링크를 복사했어요.")` 로 구현해야하는데, 이건 비효율적인 것 같아서 별도의 SharedFlow 로 신호 받아서 처리하도록 구현했습니다)

## Links
- https://www.figma.com/design/kZd5C2Mgr2NHKYvefeztSu/Design-file?node-id=1480-6987&t=tQWusB3nrfi58l1P-4

## Screenshot
https://github.com/user-attachments/assets/f9ad453c-45ac-492f-bd5b-12ca35181c16
