### PR TITLE
[#117] PicPhotoCard 확장성 개선

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -1,7 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 
 import androidx.annotation.DrawableRes
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -16,7 +15,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -25,6 +23,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.GroupInfo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
 
 @Composable
 fun PicPhotoCard(
@@ -118,9 +117,9 @@ fun PicPhotoCardFrame(
 
 @Composable
 private fun KeywordMiniSymbol(modifier: Modifier, keyword: GroupKeyword) {
-    Image(
+    StableImage(
         modifier = modifier.size(10.dp),
-        painter = painterResource(id = keyword.symbolResId),
+        drawableResId = keyword.symbolResId,
         contentDescription = stringResource(R.string.group_symbol),
     )
 }
@@ -136,9 +135,9 @@ private fun GroupImage(
         modifier = modifier,
     ) {
         content()
-        Image(
+        StableImage(
             modifier = Modifier.fillMaxSize(),
-            painter = painterResource(frameResId),
+            drawableResId = frameResId,
             colorFilter = ColorFilter.tint(backgroundColor),
             contentScale = ContentScale.FillBounds,
             contentDescription = null,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -23,7 +24,6 @@ import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.GroupInfo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
-import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
 
 @Composable
@@ -33,7 +33,8 @@ fun PicPhotoCard(
 ) {
     PicPhotoCardFrame(
         modifier = modifier,
-        groupInfo = groupInfo
+        keywordType = groupInfo.keyword,
+        frameResId = groupInfo.frontImageFrame.frameResId
     ) {
         AsyncImage(
             modifier = Modifier.matchParentSize(),
@@ -47,13 +48,14 @@ fun PicPhotoCard(
 @Composable
 fun PicPhotoCardFrame(
     modifier: Modifier,
-    groupInfo: GroupInfo,
+    keywordType: GroupKeyword,
+    @DrawableRes frameResId: Int,
     content: @Composable BoxScope.() -> Unit,
 ) {
     Box(
         modifier = modifier
             .background(
-                color = groupInfo.keyword.backgroundColor,
+                color = keywordType.backgroundColor,
                 shape = RoundedCornerShape(20.dp),
             )
             .border(
@@ -69,7 +71,7 @@ fun PicPhotoCardFrame(
                     top = 24.dp,
                     start = 22.dp,
                 ),
-            keyword = groupInfo.keyword,
+            keyword = keywordType,
         )
 
         KeywordMiniSymbol(
@@ -79,7 +81,7 @@ fun PicPhotoCardFrame(
                     top = 24.dp,
                     end = 22.dp,
                 ),
-            keyword = groupInfo.keyword,
+            keyword = keywordType,
         )
 
         KeywordMiniSymbol(
@@ -89,7 +91,7 @@ fun PicPhotoCardFrame(
                     bottom = 24.dp,
                     start = 22.dp,
                 ),
-            keyword = groupInfo.keyword,
+            keyword = keywordType,
         )
 
         KeywordMiniSymbol(
@@ -99,7 +101,7 @@ fun PicPhotoCardFrame(
                     bottom = 24.dp,
                     end = 22.dp,
                 ),
-            keyword = groupInfo.keyword,
+            keyword = keywordType,
         )
 
         GroupImage(
@@ -107,7 +109,8 @@ fun PicPhotoCardFrame(
                 .fillMaxSize()
                 .padding(top = 74.dp, bottom = 96.dp, start = 30.dp, end = 30.dp)
                 .align(Alignment.Center),
-            groupInfo = groupInfo,
+            frameResId = frameResId,
+            backgroundColor = keywordType.backgroundColor,
             content = content,
         )
     }
@@ -125,7 +128,8 @@ private fun KeywordMiniSymbol(modifier: Modifier, keyword: GroupKeyword) {
 @Composable
 private fun GroupImage(
     modifier: Modifier,
-    groupInfo: GroupInfo,
+    @DrawableRes frameResId: Int,
+    backgroundColor: Color,
     content: @Composable BoxScope.() -> Unit,
 ) {
     Box(
@@ -134,8 +138,8 @@ private fun GroupImage(
         content()
         Image(
             modifier = Modifier.fillMaxSize(),
-            painter = painterResource(id = groupInfo.frontImageFrame.frameResId),
-            colorFilter = ColorFilter.tint(groupInfo.keyword.backgroundColor),
+            painter = painterResource(frameResId),
+            colorFilter = ColorFilter.tint(backgroundColor),
             contentScale = ContentScale.FillBounds,
             contentDescription = null,
         )
@@ -147,17 +151,8 @@ private fun GroupImage(
 fun PicPhotoCardFramePreview() {
     PicPhotoCardFrame(
         modifier = Modifier.fillMaxSize(),
-        groupInfo = GroupInfo(
-            id = 0L,
-            cardBackImages = listOf(),
-            cardFrontImageUrl = "cardFrontImageUrl",
-            frontImageFrame = PicPhotoFrame.HAMBURGER,
-            keyword = GroupKeyword.SCHOOL,
-            name = "name",
-            recentEventDate = "recentEventDate",
-            status = GroupStatusType.AFTER_MY_UPLOAD,
-            statusDescription = "statusDescription",
-        )
+        keywordType = GroupKeyword.CREW,
+        frameResId = PicPhotoFrame.HAMBURGER.frameResId,
     ) {
         Box(modifier = Modifier.fillMaxSize().background(Color.Green))
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,16 +17,38 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.GroupInfo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
 
 @Composable
 fun PicPhotoCard(
     modifier: Modifier,
     groupInfo: GroupInfo,
+) {
+    PicPhotoCardFrame(
+        modifier = modifier,
+        groupInfo = groupInfo
+    ) {
+        AsyncImage(
+            modifier = Modifier.matchParentSize(),
+            model = groupInfo.cardFrontImageUrl,
+            contentScale = ContentScale.Crop,
+            contentDescription = stringResource(R.string.group_main_picture),
+        )
+    }
+}
+
+@Composable
+fun PicPhotoCardFrame(
+    modifier: Modifier,
+    groupInfo: GroupInfo,
+    content: @Composable BoxScope.() -> Unit,
 ) {
     Box(
         modifier = modifier
@@ -85,6 +108,7 @@ fun PicPhotoCard(
                 .padding(top = 74.dp, bottom = 96.dp, start = 30.dp, end = 30.dp)
                 .align(Alignment.Center),
             groupInfo = groupInfo,
+            content = content,
         )
     }
 }
@@ -99,17 +123,15 @@ private fun KeywordMiniSymbol(modifier: Modifier, keyword: GroupKeyword) {
 }
 
 @Composable
-private fun GroupImage(modifier: Modifier, groupInfo: GroupInfo) {
+private fun GroupImage(
+    modifier: Modifier,
+    groupInfo: GroupInfo,
+    content: @Composable BoxScope.() -> Unit,
+) {
     Box(
         modifier = modifier,
     ) {
-        AsyncImage(
-            modifier = Modifier.matchParentSize(),
-            model = groupInfo.cardFrontImageUrl,
-            contentScale = ContentScale.Crop,
-            contentDescription = stringResource(R.string.group_main_picture),
-        )
-
+        content()
         Image(
             modifier = Modifier.fillMaxSize(),
             painter = painterResource(id = groupInfo.frontImageFrame.frameResId),
@@ -117,5 +139,26 @@ private fun GroupImage(modifier: Modifier, groupInfo: GroupInfo) {
             contentScale = ContentScale.FillBounds,
             contentDescription = null,
         )
+    }
+}
+
+@Preview
+@Composable
+fun PicPhotoCardFramePreview() {
+    PicPhotoCardFrame(
+        modifier = Modifier.fillMaxSize(),
+        groupInfo = GroupInfo(
+            id = 0L,
+            cardBackImages = listOf(),
+            cardFrontImageUrl = "cardFrontImageUrl",
+            frontImageFrame = PicPhotoFrame.HAMBURGER,
+            keyword = GroupKeyword.SCHOOL,
+            name = "name",
+            recentEventDate = "recentEventDate",
+            status = GroupStatusType.AFTER_MY_UPLOAD,
+            statusDescription = "statusDescription",
+        )
+    ) {
+        Box(modifier = Modifier.fillMaxSize().background(Color.Green))
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -33,7 +33,7 @@ fun PicPhotoCard(
     PicPhotoCardFrame(
         modifier = modifier,
         keywordType = groupInfo.keyword,
-        frameResId = groupInfo.frontImageFrame.frameResId
+        frameResId = groupInfo.frontImageFrame.frameResId,
     ) {
         AsyncImage(
             modifier = Modifier.matchParentSize(),
@@ -153,6 +153,10 @@ fun PicPhotoCardFramePreview() {
         keywordType = GroupKeyword.CREW,
         frameResId = PicPhotoFrame.HAMBURGER.frameResId,
     ) {
-        Box(modifier = Modifier.fillMaxSize().background(Color.Green))
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Green),
+        )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/StableImage.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/StableImage.kt
@@ -5,13 +5,15 @@ import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 
 @Composable
 fun StableImage(
     modifier: Modifier = Modifier,
     @DrawableRes drawableResId: Int,
-    contentDescription: String,
+    contentDescription: String?,
+    contentScale: ContentScale = ContentScale.Fit,
     colorFilter: ColorFilter? = null,
 ) {
     val painter = painterResource(id = drawableResId)
@@ -19,6 +21,7 @@ fun StableImage(
         modifier = modifier,
         painter = painter,
         contentDescription = contentDescription,
+        contentScale = contentScale,
         colorFilter = colorFilter,
     )
 }


### PR DESCRIPTION
## Issue No
- close #117 

## Overview (Required)
- PicPhotoCard 안에 이미지가 아닌 화면이 들어가는 케이스가 있어서.. 이거를 편하게 할 수 있도록 작업하게 되었습니다
- PicPhotoCard 을 좀 더 재사용하기 쉬우면서도 기존코드에 영향가지 않도록 리팩토링 하는 것이 목적입니다


## Screenshot
![image](https://github.com/user-attachments/assets/19f2537d-d851-4a8c-bcb2-b90e1c9bcdb7)
이렇게 사진이 들어갈 때도 있지만

![image](https://github.com/user-attachments/assets/f2d511f9-1762-412f-b2e2-1d3a0c51aa63)
이렇게 사진이 아닌 화면이 들어갈 때도 있다.