### PR TITLE
[#108] 그룹상세 프레임 적용

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.GroupInfo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
@@ -103,7 +104,7 @@ fun PicPhotoCardFrame(
             keyword = keywordType,
         )
 
-        GroupImage(
+        PicCroppedImageContainer(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = 74.dp, bottom = 96.dp, start = 30.dp, end = 30.dp)
@@ -125,7 +126,7 @@ private fun KeywordMiniSymbol(modifier: Modifier, keyword: GroupKeyword) {
 }
 
 @Composable
-private fun GroupImage(
+private fun PicCroppedImageContainer(
     modifier: Modifier,
     @DrawableRes frameResId: Int,
     backgroundColor: Color,
@@ -143,6 +144,37 @@ private fun GroupImage(
             contentDescription = null,
         )
     }
+}
+
+@Composable
+fun PicCroppedPhoto(
+    modifier: Modifier,
+    imageUrl: String,
+    @DrawableRes frameResId: Int,
+    backgroundColor: Color = Gray0,
+) {
+    PicCroppedImageContainer(
+        modifier = modifier,
+        frameResId = frameResId,
+        backgroundColor = backgroundColor,
+    ) {
+        AsyncImage(
+            modifier = Modifier.matchParentSize(),
+            model = imageUrl,
+            contentScale = ContentScale.Crop,
+            contentDescription = stringResource(R.string.group_main_picture),
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PicCroppedPhotoPreview() {
+    PicCroppedPhoto(
+        modifier = Modifier.fillMaxSize(),
+        frameResId = PicPhotoFrame.PLUS.frameResId,
+        imageUrl = "https://picsum.photos/200/300",
+    )
 }
 
 @Preview

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -24,7 +24,6 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.mashup.gabbangzip.sharedalbum.presentation.R
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -29,18 +29,23 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.pretendard
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.preview.GroupStatusProvider
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.GroupEvent
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.GroupEventActionButtonState
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.getActionButtonState
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
 
 @Composable
 fun RecentEventContainer(
     modifier: Modifier = Modifier,
     status: GroupStatusType,
     event: GroupEvent,
+    keyword: GroupKeyword,
+    cardFrontImageUrl: String,
     onClickActionButton: (GroupStatusType) -> Unit,
     onClickShareButton: () -> Unit,
 ) {
@@ -55,12 +60,12 @@ fun RecentEventContainer(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             RecentEventSummary(event = event)
-            // TODO: 사진 프레임으로 교체 필요
-            Box(
+            PicCroppedPhoto(
                 modifier = Modifier
                     .padding(top = 16.dp)
-                    .size(240.dp)
-                    .background(color = Gray60),
+                    .size(240.dp),
+                frameResId = PicPhotoFrame.getTypeByKeyword(keyword.name).frameResId,
+                imageUrl = cardFrontImageUrl,
             )
             status.getActionButtonState()?.let { buttonState ->
                 RecentEventBottomSection(
@@ -187,6 +192,8 @@ private fun RecentEventPreview(
                 date = "2024.11.03",
                 deadline = "6월 14일 월요일 PIC 종료",
             ),
+            keyword = GroupKeyword.SCHOOL,
+            cardFrontImageUrl = "https://picsum.photos/200/300",
             onClickActionButton = {},
             onClickShareButton = {},
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -24,6 +24,7 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,7 +53,9 @@ fun GroupDetailScreen(
     }
 
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Gray0),
     ) {
         PicBackButtonTopBar(
             modifier = Modifier.fillMaxWidth(),
@@ -106,6 +109,7 @@ private fun GroupDetailScreenContent(
             RecentEventContainer(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .background(Gray0)
                     .padding(top = 10.dp),
                 status = state.status,
                 event = state.recentEvent,
@@ -129,7 +133,7 @@ private fun GroupDetailScreenPreview(
                 groupInfo = GroupInfo(
                     id = 0,
                     cardBackImages = emptyList(),
-                    cardFrontImageUrl = "",
+                    cardFrontImageUrl = "https://picsum.photos/200/300",
                     keyword = GroupKeyword.SCHOOL,
                     name = "가빵집가빵집",
                     recentEventDate = "2024.11.01",

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -109,6 +109,8 @@ private fun GroupDetailScreenContent(
                     .padding(top = 10.dp),
                 status = state.status,
                 event = state.recentEvent,
+                keyword = state.groupInfo?.keyword ?: GroupKeyword.SCHOOL,
+                cardFrontImageUrl = state.groupInfo?.cardFrontImageUrl.orEmpty(),
                 onClickActionButton = onClickActionButton,
                 onClickShareButton = onClickShareButton,
             )


### PR DESCRIPTION
## Issue No
- close #108 

## Overview (Required)
- 포토카드 없이 크롭된 이미지가 필요해서 PicCroppedPhoto 컴포저블 추가했습니당
- 그룹상세 프레임 적용
- 그룹상세 배경색 Gray0 적용

## Screenshot
![스크린샷 2024-07-27 오후 5 21 33](https://github.com/user-attachments/assets/b0689a97-8872-4e1d-ad39-9cf66432d582)