### PR TITLE
[#122] 그룹생성 초대코드 복사하기 추가

### DIFF
--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/CreateGroupResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/CreateGroupResponse.kt
@@ -13,6 +13,6 @@ data class CreateGroupResponse(
     val keyword: String,
     @Json(name = "group_image_url")
     val groupImageUrl: String,
-    @Json(name = "group_invitation_url")
-    val groupInvitationUrl: String? = null, // Todo : 초대코드 대응하기
+    @Json(name = "invitation_code")
+    val invitationCode: String,
 )

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
@@ -27,7 +27,7 @@ class GroupRepositoryImpl @Inject constructor(
                 name = groupName,
                 keyword = keyword,
                 imageUrl = "${Constants.S3_BUCKET_DOMAIN_URl}$groupImageUrl",
-                invitationUrl = groupInvitationUrl ?: "", // Todo : 초대코드 대응하기
+                invitationCode = invitationCode
             )
         }
     }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
@@ -27,7 +27,7 @@ class GroupRepositoryImpl @Inject constructor(
                 name = groupName,
                 keyword = keyword,
                 imageUrl = "${Constants.S3_BUCKET_DOMAIN_URl}$groupImageUrl",
-                invitationCode = invitationCode
+                invitationCode = invitationCode,
             )
         }
     }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/model/group/GroupInfoDomainModel.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/model/group/GroupInfoDomainModel.kt
@@ -5,5 +5,5 @@ data class GroupInfoDomainModel(
     val name: String,
     val keyword: String,
     val imageUrl: String,
-    val invitationUrl: String,
+    val invitationCode: String,
 )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
@@ -66,7 +66,7 @@ class GroupCreationViewModel @Inject constructor(
                             name = it.name,
                             keyword = GroupKeyword.getKeyword(it.keyword),
                             imageUrl = it.imageUrl,
-                            invitationUrl = it.invitationUrl,
+                            invitationCode = it.invitationCode,
                         ),
                     ),
                 )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -103,8 +103,8 @@ fun GroupCreationCompleteScreen(
                         showSnackBarMessage(PicSnackbarType.CHECK, copyLinkMessage)
                         clipboardManager.setText(
                             AnnotatedString(
-                                invitationMessage.format(playStoreUrl, appStoreUrl, invitationCode)
-                            )
+                                invitationMessage.format(playStoreUrl, appStoreUrl, invitationCode),
+                            ),
                         )
                     }
                 },

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -41,6 +41,9 @@ fun GroupCreationCompleteScreen(
 ) {
     val clipboardManager = LocalClipboardManager.current
     val copyLinkMessage = stringResource(id = R.string.button_copy_link_message)
+    val invitationMessage = stringResource(id = R.string.invitation_message)
+    val playStoreUrl = stringResource(id = R.string.play_store_url)
+    val appStoreUrl = stringResource(id = R.string.app_store_url)
     Column {
         PicTextOnlyTopBar(
             modifier = Modifier
@@ -98,7 +101,11 @@ fun GroupCreationCompleteScreen(
                 onButtonClicked = {
                     groupCreationResult?.invitationCode?.let { invitationCode ->
                         showSnackBarMessage(PicSnackbarType.CHECK, copyLinkMessage)
-                        clipboardManager.setText(AnnotatedString(invitationCode))
+                        clipboardManager.setText(
+                            AnnotatedString(
+                                invitationMessage.format(playStoreUrl, appStoreUrl, invitationCode)
+                            )
+                        )
                     }
                 },
             )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -96,9 +96,9 @@ fun GroupCreationCompleteScreen(
                 contentColor = Gray80,
                 iconRes = R.drawable.ic_link,
                 onButtonClicked = {
-                    groupCreationResult?.invitationUrl?.let { invitationUrl ->
+                    groupCreationResult?.invitationCode?.let { invitationCode ->
                         showSnackBarMessage(PicSnackbarType.CHECK, copyLinkMessage)
-                        clipboardManager.setText(AnnotatedString(invitationUrl))
+                        clipboardManager.setText(AnnotatedString(invitationCode))
                     }
                 },
             )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/model/GroupCreationResult.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/model/GroupCreationResult.kt
@@ -6,5 +6,5 @@ data class GroupCreationResult(
     val name: String,
     val keyword: GroupKeyword,
     val imageUrl: String,
-    val invitationUrl: String,
+    val invitationCode: String,
 )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/splash/SplashActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.GroupCreationActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.login.LoginActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -35,7 +36,7 @@ class SplashActivity : ComponentActivity() {
 
                 when (state.isUserLoggedIn) {
                     true -> {
-                        MainActivity.openActivity(this)
+                        GroupCreationActivity.openActivity(this)
                         finish()
                     }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/splash/SplashActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
-import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.GroupCreationActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.login.LoginActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,7 +35,7 @@ class SplashActivity : ComponentActivity() {
 
                 when (state.isUserLoggedIn) {
                     true -> {
-                        GroupCreationActivity.openActivity(this)
+                        MainActivity.openActivity(this)
                         finish()
                     }
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <string name="group_creation_name_title">그룹의 이름은 무엇인가요?</string>
     <string name="group_creation_name_hint">최대 10자 까지 입력 가능해요.</string>
     <string name="group_creation_keyword_title">그룹의 키워드를 선택해 주세요</string>
+    <string name="invitation_message">PIC 앱 다운받기\n- PlayStore: %s\n- AppStore: %s\n초대코드: %s</string>
+    <string name="play_store_url">https://play.google.com/store/apps/details?id=com.ebay.kr.gmarket</string>
+    <string name="app_store_url">https://apps.apple.com/kr/app/g%EB%A7%88%EC%BC%93/id11111111</string>
 
     <string name="event_creation">이벤트 만들기</string>
     <string name="event_creation_title">이벤트를 생성하고\n함께한 순간을 공유해요!</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -77,7 +77,7 @@
     <string name="group_leader">그룹장</string>
     <string name="group_add_more_member">그룹원을 추가하고 싶으세요?</string>
     <string name="group_maximum_count">그룹 최대 인원은 6명이에요.</string>
-    <string name="button_copy_link">링크 복사</string>
+    <string name="button_copy_link">초대코드 복사</string>
     <string name="vote_icon">투표 아이콘</string>
     <string name="vote_dislike_desc">싫어요</string>
     <string name="vote_like_desc">좋아요</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -39,8 +39,8 @@
     <string name="group_creation_name_hint">최대 10자 까지 입력 가능해요.</string>
     <string name="group_creation_keyword_title">그룹의 키워드를 선택해 주세요</string>
     <string name="invitation_message">PIC 앱 다운받기\n- PlayStore: %s\n- AppStore: %s\n초대코드: %s</string>
-    <string name="play_store_url">https://play.google.com/store/apps/details?id=com.ebay.kr.gmarket</string>
-    <string name="app_store_url">https://apps.apple.com/kr/app/g%EB%A7%88%EC%BC%93/id11111111</string>
+    <string name="play_store_url">https://play.google.com/store/apps/details?id=com.mashup.gabbangzip.sharedalbum</string>
+    <string name="app_store_url">https://apps.apple.com/kr/app/pic/id11111111</string>
 
     <string name="event_creation">이벤트 만들기</string>
     <string name="event_creation_title">이벤트를 생성하고\n함께한 순간을 공유해요!</string>


### PR DESCRIPTION
## Issue No
- close #122 

## Overview (Required)
- 그룹생성 초대코드 대응
- 그룹 초대링크가 아닌 초대코드로 받도록 수정했습니다

## Links
- https://www.figma.com/design/kZd5C2Mgr2NHKYvefeztSu/Design-file?node-id=1480-6987&t=ovRz52H9U45DVLTM-4

## ScreenShots
![image](https://github.com/user-attachments/assets/bbccb8d6-f2e2-4f2e-8b00-545777aeb35d)
