### PR TITLE
[#138] 그룹 홈 화면 Card 플립 효과 개선

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/FlippableBox.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/FlippableBox.kt
@@ -82,7 +82,7 @@ fun FlippableBox(
             }
             .graphicsLayer {
                 rotationY = nativeAnimatedRotationAngle + if (isFront) 0f else 180f
-                cameraDistance = 18f * density
+                cameraDistance = 18.dp.toPx()
             },
         content = if (isFront) frontScreen else backScreen,
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/FlippableBox.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/FlippableBox.kt
@@ -82,6 +82,7 @@ fun FlippableBox(
             }
             .graphicsLayer {
                 rotationY = nativeAnimatedRotationAngle + if (isFront) 0f else 180f
+                cameraDistance = 18f * density
             },
         content = if (isFront) frontScreen else backScreen,
     )


### PR DESCRIPTION
## Issue No
- close #138 

## Overview (Required)
- 카드 플립할때 영역 넘어가지 않도록 조정했습니당~
- 계원이가 워낙 잘 구현해줘서 간단하게 해결됐습니다 ㅋㄷㅋㄷ 지렸다리.

## Screenshot

https://github.com/user-attachments/assets/054039fc-efe7-4212-92c9-29005c4c721d

