### PR TITLE
[#171][#155] 그룹상세 우리들의 인생네컷 프레임, 이미지뷰어 스크린

### DIFF
--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/GroupDetailResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/GroupDetailResponse.kt
@@ -36,5 +36,6 @@ fun GroupDetailResponse.toDomainModel(): GroupDomainModel {
         recentEvent = recentEvent.toDomainModel(),
         status = status,
         statusDescription = statusDescription,
+        history = history.map { it.toDomainModel() },
     )
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/HistoryResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/HistoryResponse.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.data.dto.response.group
 
+import com.mashup.gabbangzip.sharedalbum.data.common.toLocalDateTime
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.HistoryDomainModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -20,7 +21,7 @@ fun HistoryResponse.toDomainModel(): HistoryDomainModel {
     return HistoryDomainModel(
         id = id,
         name = name,
-        date = date,
+        date = date.toLocalDateTime(),
         images = images.map { it.toDomainModel() },
     )
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/model/group/HistoryDomainModel.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/model/group/HistoryDomainModel.kt
@@ -1,8 +1,10 @@
 package com.mashup.gabbangzip.sharedalbum.domain.model.group
 
+import java.time.LocalDateTime
+
 data class HistoryDomainModel(
     val id: Long,
     val name: String,
-    val date: String,
+    val date: LocalDateTime,
     val images: List<CardBackImageDomainModel>,
 )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTopBar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTopBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -65,6 +66,7 @@ fun PicTopBar(
 @Composable
 fun PicBackButtonTopBar(
     modifier: Modifier = Modifier,
+    isLightMode: Boolean = true,
     titleText: String,
     titleAlign: PicTopBarTitleAlign = PicTopBarTitleAlign.CENTER,
     backButtonClicked: () -> Unit,
@@ -91,6 +93,7 @@ fun PicBackButtonTopBar(
                     .noRippleClickable { backButtonClicked() }
                     .size(26.dp),
                 painter = painterResource(id = PicTopBarIcon.BACK.iconRes),
+                colorFilter = ColorFilter.tint(color = if (isLightMode) Gray80 else Gray0),
                 contentDescription = stringResource(id = PicTopBarIcon.BACK.desc),
             )
             if (titleAlign == PicTopBarTitleAlign.LEFT) {
@@ -100,7 +103,7 @@ fun PicBackButtonTopBar(
                         .weight(1.0f),
                     text = titleText,
                     style = PicTypography.bodyMedium16,
-                    color = Gray80,
+                    color = if (isLightMode) Gray80 else Gray0,
                 )
             }
             if (rightIcon1 != null) {
@@ -129,7 +132,7 @@ fun PicBackButtonTopBar(
                 text = titleText,
                 textAlign = TextAlign.Center,
                 style = PicTypography.bodyMedium16,
-                color = Gray80,
+                color = if (isLightMode) Gray80 else Gray0,
             )
         }
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailHistory.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailHistory.kt
@@ -34,6 +34,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.preview.EventHistoryProvider
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.noRippleClickable
@@ -41,6 +42,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.utils.noRippleClickable
 @Composable
 fun EventHistoryContainer(
     modifier: Modifier = Modifier,
+    backgroundColor: Color,
     history: List<HistoryItem>,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
@@ -61,6 +63,7 @@ fun EventHistoryContainer(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 16.dp),
+                backgroundColor = backgroundColor,
                 history = history,
                 onClickHistoryItem = onClickHistoryItem,
             )
@@ -94,6 +97,7 @@ private fun EventHistoryEmptyContent(
 @Composable
 private fun EventHistoryGridContent(
     modifier: Modifier = Modifier,
+    backgroundColor: Color,
     history: List<HistoryItem>,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
@@ -106,6 +110,7 @@ private fun EventHistoryGridContent(
     ) {
         items(history) { item ->
             EventHistoryItemContainer(
+                backgroundColor = backgroundColor,
                 item = item,
                 onClickHistoryItem = onClickHistoryItem,
             )
@@ -116,6 +121,7 @@ private fun EventHistoryGridContent(
 @Composable
 private fun EventHistoryItemContainer(
     modifier: Modifier = Modifier,
+    backgroundColor: Color,
     item: HistoryItem,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
@@ -129,7 +135,7 @@ private fun EventHistoryItemContainer(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f),
-            backgroundColor = Gray60,
+            backgroundColor = backgroundColor,
             cardBackImageList = item.images,
         )
         Text(
@@ -187,6 +193,7 @@ private fun EventHistoryContainerPreview(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
+        backgroundColor = GroupKeyword.SCHOOL.behindCardBackGroundColor,
         history = history,
         onClickHistoryItem = {},
     )
@@ -196,6 +203,7 @@ private fun EventHistoryContainerPreview(
 @Composable
 private fun EventHistoryItemPreview() {
     EventHistoryItemContainer(
+        backgroundColor = GroupKeyword.SCHOOL.behindCardBackGroundColor,
         item = HistoryItem(
             title = "가빵집 MT",
             date = "2024.11.03",

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailHistory.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailHistory.kt
@@ -42,7 +42,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.utils.noRippleClickable
 @Composable
 fun EventHistoryContainer(
     modifier: Modifier = Modifier,
-    backgroundColor: Color,
+    thumbnailBackgroundColor: Color,
     history: List<HistoryItem>,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
@@ -63,7 +63,7 @@ fun EventHistoryContainer(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 16.dp),
-                backgroundColor = backgroundColor,
+                thumbnailBackgroundColor = thumbnailBackgroundColor,
                 history = history,
                 onClickHistoryItem = onClickHistoryItem,
             )
@@ -97,7 +97,7 @@ private fun EventHistoryEmptyContent(
 @Composable
 private fun EventHistoryGridContent(
     modifier: Modifier = Modifier,
-    backgroundColor: Color,
+    thumbnailBackgroundColor: Color,
     history: List<HistoryItem>,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
@@ -110,7 +110,7 @@ private fun EventHistoryGridContent(
     ) {
         items(history) { item ->
             EventHistoryItemContainer(
-                backgroundColor = backgroundColor,
+                thumbnailBackgroundColor = thumbnailBackgroundColor,
                 item = item,
                 onClickHistoryItem = onClickHistoryItem,
             )
@@ -121,7 +121,7 @@ private fun EventHistoryGridContent(
 @Composable
 private fun EventHistoryItemContainer(
     modifier: Modifier = Modifier,
-    backgroundColor: Color,
+    thumbnailBackgroundColor: Color,
     item: HistoryItem,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
@@ -135,7 +135,7 @@ private fun EventHistoryItemContainer(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(1f),
-            backgroundColor = backgroundColor,
+            backgroundColor = thumbnailBackgroundColor,
             cardBackImageList = item.images,
         )
         Text(
@@ -193,7 +193,7 @@ private fun EventHistoryContainerPreview(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp),
-        backgroundColor = GroupKeyword.SCHOOL.behindCardBackGroundColor,
+        thumbnailBackgroundColor = GroupKeyword.SCHOOL.behindCardBackGroundColor,
         history = history,
         onClickHistoryItem = {},
     )
@@ -203,7 +203,7 @@ private fun EventHistoryContainerPreview(
 @Composable
 private fun EventHistoryItemPreview() {
     EventHistoryItemContainer(
-        backgroundColor = GroupKeyword.SCHOOL.behindCardBackGroundColor,
+        thumbnailBackgroundColor = GroupKeyword.SCHOOL.behindCardBackGroundColor,
         item = HistoryItem(
             title = "가빵집 MT",
             date = "2024.11.03",

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailHistory.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailHistory.kt
@@ -10,13 +10,17 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,8 +30,11 @@ import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.preview.EventHistoryProvider
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.noRippleClickable
 
@@ -118,11 +125,12 @@ private fun EventHistoryItemContainer(
                 onClickHistoryItem(item)
             },
     ) {
-        Box(
+        HistoryThumbnail(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(1f)
-                .background(color = Gray60),
+                .aspectRatio(1f),
+            backgroundColor = Gray60,
+            cardBackImageList = item.images,
         )
         Text(
             modifier = Modifier.padding(top = 6.dp),
@@ -136,6 +144,37 @@ private fun EventHistoryItemContainer(
             style = PicTypography.captionNormal12,
             color = Gray60,
         )
+    }
+}
+
+@Composable
+private fun HistoryThumbnail(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color,
+    cardBackImageList: ImmutableList<CardBackImage>,
+) {
+    Box(
+        modifier = modifier
+            .clip(shape = RoundedCornerShape(12.dp))
+            .background(color = backgroundColor)
+            .padding(10.dp),
+    ) {
+        LazyVerticalGrid(
+            modifier = Modifier.wrapContentSize(),
+            verticalArrangement = Arrangement.spacedBy(5.dp),
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
+            columns = GridCells.Fixed(2),
+            userScrollEnabled = false,
+        ) {
+            items(items = cardBackImageList) { cardBackImage ->
+                PicCroppedPhoto(
+                    modifier = Modifier.aspectRatio(1f),
+                    imageUrl = cardBackImage.imageUrl,
+                    frameResId = cardBackImage.frameType.frameResId,
+                    backgroundColor = backgroundColor,
+                )
+            }
+        }
     }
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -152,7 +152,7 @@ private fun GroupDetailScreenContent(
                         .padding(horizontal = 16.dp),
                     history = state.history,
                     onClickHistoryItem = onClickHistoryItem,
-                    backgroundColor = state.groupInfo?.keyword?.behindCardBackGroundColor
+                    thumbnailBackgroundColor = state.groupInfo?.keyword?.behindCardBackGroundColor
                         ?: GroupKeyword.SCHOOL.behindCardBackGroundColor,
                 )
             },

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -138,6 +138,8 @@ private fun GroupDetailScreenContent(
                         .padding(horizontal = 16.dp),
                     history = state.history,
                     onClickHistoryItem = onClickHistoryItem,
+                    backgroundColor = state.groupInfo?.keyword?.behindCardBackGroundColor
+                        ?: GroupKeyword.SCHOOL.behindCardBackGroundColor,
                 )
             },
         ) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -1,0 +1,138 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicPhotoCardFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
+
+@Composable
+fun HistoryDetailScreen(
+
+) {
+
+}
+
+@Composable
+private fun HistoryPhotoCard(
+    modifier: Modifier = Modifier,
+    keyword: GroupKeyword,
+    item: HistoryItem,
+) {
+    Box(modifier = modifier.wrapContentSize()) {
+        PicPhotoCardFrame(
+            modifier = Modifier.matchParentSize(),
+            keywordType = keyword,
+            frameResId = PicPhotoFrame.getTypeByKeyword(keyword.name).frameResId,
+            content = {},
+        )
+        Column(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                modifier = Modifier
+                    .padding(top = 40.dp, bottom = 24.dp),
+                text = item.date,
+                style = PicTypography.bodyMedium16,
+            )
+            GridPhotoSection(
+                backgroundColor = keyword.frontCardBackgroundColor,
+                images = item.images,
+            )
+            Text(
+                modifier = Modifier
+                    .padding(top = 28.dp, bottom = 48.dp),
+                text = item.title,
+                style = PicTypography.headBold20,
+            )
+        }
+    }
+}
+
+@Composable
+private fun GridPhotoSection(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color,
+    images: ImmutableList<CardBackImage>,
+) {
+    LazyVerticalGrid(
+        modifier = modifier.wrapContentSize(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        columns = GridCells.Fixed(2),
+        userScrollEnabled = false,
+    ) {
+        items(items = images) { image ->
+            PicCroppedPhoto(
+                modifier = Modifier.aspectRatio(1f),
+                imageUrl = image.imageUrl,
+                frameResId = image.frameType.frameResId,
+                backgroundColor = backgroundColor,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun HistoryPhotoCardPreview() {
+    SharedAlbumTheme {
+        HistoryPhotoCard(
+            keyword = GroupKeyword.CREW,
+            item = HistoryItem(
+                id = 0,
+                title = "MTT",
+                date = "2024.01.11",
+                images = ImmutableList(
+                    listOf(
+                        CardBackImage(
+                            imageUrl = "https://picsum.photos/200/300",
+                            frameType = PicPhotoFrame.HAMBURGER,
+                        ),
+                        CardBackImage(
+                            imageUrl = "https://picsum.photos/200/300",
+                            frameType = PicPhotoFrame.PLUS,
+                        ),
+                        CardBackImage(
+                            imageUrl = "https://picsum.photos/200/300",
+                            frameType = PicPhotoFrame.GHOST,
+                        ),
+                        CardBackImage(
+                            imageUrl = "https://picsum.photos/200/300",
+                            frameType = PicPhotoFrame.SEXY,
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun HistoryDetailScreenPreview() {
+    SharedAlbumTheme {
+        HistoryDetailScreen()
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -1,9 +1,11 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -16,10 +18,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicBackButtonTopBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicPhotoCardFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTopBarTitleAlign
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
@@ -28,9 +33,33 @@ import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 
 @Composable
 fun HistoryDetailScreen(
-
+    groupName: String,
+    keyword: GroupKeyword,
+    item: HistoryItem,
+    onClickBackButton: () -> Unit,
 ) {
-
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.Black),
+    ) {
+        PicBackButtonTopBar(
+            modifier = Modifier
+                .background(Gray0.copy(alpha = 0.1f))
+                .padding(top = 56.dp),
+            isLightMode = false,
+            titleText = groupName,
+            titleAlign = PicTopBarTitleAlign.LEFT,
+            backButtonClicked = onClickBackButton,
+        )
+        HistoryPhotoCard(
+            modifier = Modifier
+                .weight(1f)
+                .wrapContentSize(),
+            keyword = keyword,
+            item = item,
+        )
+    }
 }
 
 @Composable
@@ -96,9 +125,10 @@ private fun GridPhotoSection(
 
 @Composable
 @Preview(showBackground = true)
-private fun HistoryPhotoCardPreview() {
+private fun HistoryDetailScreenPreview() {
     SharedAlbumTheme {
-        HistoryPhotoCard(
+        HistoryDetailScreen(
+            groupName = "가빵집",
             keyword = GroupKeyword.CREW,
             item = HistoryItem(
                 id = 0,
@@ -125,14 +155,7 @@ private fun HistoryPhotoCardPreview() {
                     ),
                 ),
             ),
+            onClickBackButton = {},
         )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-private fun HistoryDetailScreenPreview() {
-    SharedAlbumTheme {
-        HistoryDetailScreen()
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -54,8 +54,7 @@ fun HistoryDetailScreen(
         )
         HistoryPhotoCard(
             modifier = Modifier
-                .weight(1f)
-                .wrapContentSize(),
+                .weight(1f),
             keyword = keyword,
             item = item,
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/HistoryItem.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/HistoryItem.kt
@@ -1,6 +1,11 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model
 
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
+
 data class HistoryItem(
+    val id: Long = 0,
     val title: String,
     val date: String,
+    val images: ImmutableList<CardBackImage> = ImmutableList(emptyList()),
 )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/HistoryItem.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/HistoryItem.kt
@@ -1,7 +1,10 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model
 
+import com.mashup.gabbangzip.sharedalbum.domain.model.group.HistoryDomainModel
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.toUiModel
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.LocalDateUtil
 
 data class HistoryItem(
     val id: Long = 0,
@@ -9,3 +12,12 @@ data class HistoryItem(
     val date: String,
     val images: ImmutableList<CardBackImage> = ImmutableList(emptyList()),
 )
+
+fun HistoryDomainModel.toUiModel(): HistoryItem {
+    return HistoryItem(
+        id = id,
+        title = name,
+        date = LocalDateUtil.format(date),
+        images = ImmutableList(images.toUiModel()),
+    )
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/preview/EventHistoryProvider.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/preview/EventHistoryProvider.kt
@@ -2,30 +2,95 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.previ
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 
 class EventHistoryProvider : PreviewParameterProvider<List<HistoryItem>> {
     override val values: Sequence<List<HistoryItem>>
         get() = sequenceOf(
             emptyList(),
             listOf(
-                HistoryItem(title = "가빵집 MT1", date = "2024.11.03"),
+                HistoryItem(
+                    title = "가빵집 MT1",
+                    date = "2024.11.03",
+                ),
             ),
             listOf(
-                HistoryItem(title = "가빵집 MT1", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT2", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT3", date = "2024.11.03"),
+                HistoryItem(
+                    title = "가빵집 MT1",
+                    date = "2024.11.03",
+                    images = ImmutableList(
+                        listOf(
+                            CardBackImage(
+                                imageUrl = "https://picsum.photos/200/300",
+                                frameType = PicPhotoFrame.HAMBURGER,
+                            ),
+                            CardBackImage(
+                                imageUrl = "https://picsum.photos/200/300",
+                                frameType = PicPhotoFrame.PLUS,
+                            ),
+                            CardBackImage(
+                                imageUrl = "https://picsum.photos/200/300",
+                                frameType = PicPhotoFrame.GHOST,
+                            ),
+                            CardBackImage(
+                                imageUrl = "https://picsum.photos/200/300",
+                                frameType = PicPhotoFrame.SEXY,
+                            ),
+                        ),
+                    ),
+                ),
+                HistoryItem(
+                    title = "가빵집 MT2",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT3",
+                    date = "2024.11.03",
+                ),
             ),
             listOf(
-                HistoryItem(title = "가빵집 MT1", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT2", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT3", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT4", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT5", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT6", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT7", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT8", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT9", date = "2024.11.03"),
-                HistoryItem(title = "가빵집 MT0", date = "2024.11.03"),
+                HistoryItem(
+                    title = "가빵집 MT1",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT2",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT3",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT4",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT5",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT6",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT7",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT8",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT9",
+                    date = "2024.11.03",
+                ),
+                HistoryItem(
+                    title = "가빵집 MT0",
+                    date = "2024.11.03",
+                ),
             ),
         )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -76,7 +76,9 @@ fun GroupHomeScreen(
     onClickMyPage: () -> Unit,
     onClickGroupEnter: () -> Unit,
     onClickGroupMake: () -> Unit,
-    onClickSendFcm: () -> Unit,
+    onClickSendFcmButton: (eventId: Long) -> Unit,
+    onNavigateGallery: () -> Unit,
+    onNavigateVote: () -> Unit,
     navigateToGroupCreationAndFinish: () -> Unit,
     viewModel: GroupHomeViewModel = hiltViewModel(),
 ) {
@@ -95,7 +97,9 @@ fun GroupHomeScreen(
                 onClickMyPage = onClickMyPage,
                 onClickGroupEnter = onClickGroupEnter,
                 onClickGroupMake = onClickGroupMake,
-                onClickSendFcm = onClickSendFcm,
+                onClickSendFcmButton = onClickSendFcmButton,
+                onNavigateGallery = onNavigateGallery,
+                onNavigateVote = onNavigateVote,
             )
         }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/GroupInfo.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/GroupInfo.kt
@@ -2,6 +2,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model
 
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.GroupDomainModel
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.GroupEvent
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.toUiModel
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
@@ -17,6 +18,7 @@ data class GroupInfo(
     val recentEvent: GroupEvent,
     val status: GroupStatusType,
     val statusDescription: String,
+    val history: List<HistoryItem> = emptyList(),
 )
 
 fun GroupDomainModel.toUiModel(): GroupInfo {
@@ -30,6 +32,7 @@ fun GroupDomainModel.toUiModel(): GroupInfo {
         recentEvent = recentEvent.toUiModel(),
         status = GroupStatusType.getType(status),
         statusDescription = statusDescription,
+        history = history.map { it.toUiModel() },
     )
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/LocalDateUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/LocalDateUtil.kt
@@ -1,11 +1,19 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.utils
 
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 object LocalDateUtil {
     fun getNowDate(): String {
         val formatter = DateTimeFormatter.ofPattern("yy/MM/dd")
         return LocalDate.now().format(formatter)
+    }
+
+    fun format(date: LocalDateTime, pattern: String = "yyyy.MM.dd"): String {
+        return date
+            .atZone(ZoneId.of("Asia/Seoul"))
+            .format(DateTimeFormatter.ofPattern(pattern))
     }
 }


### PR DESCRIPTION
## Issue No
- close #171 
- close #155 

## Overview (Required)
- 우리들의 인생네컷 썸네일 컴포저블 구현
- history 맵핑 로직 추가
- LocalDateTime -> String format util 정의
- 그룹상세 이미지뷰어 스크린 구현
    - 다크모드 탑바 추가
    - 그룹상세에서 이미지뷰어 연결까지 하고 싶었는데 음.. 네비게이션이나 인텐트로 객체를 넘기는게 좀 오래걸릴 것 같아서 화면 연결은 다른 이슈로 처리하겠읍니다

## Screenshot
<img width="232" alt="스크린샷 2024-08-15 오후 4 11 19" src="https://github.com/user-attachments/assets/5ac67f49-143c-4673-9ee8-a547cfebaffa">
<br />
<img width="245" alt="스크린샷 2024-08-15 오후 4 11 36" src="https://github.com/user-attachments/assets/f01e26d2-f9f3-4b0c-84bf-e9b3e2be782e">