### PR TITLE
[#175] GroupHomeScreen 인자 전달이 연결되지 않아 생긴 빌드오류 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -76,8 +76,10 @@ fun GroupHomeScreen(
     onClickMyPage: () -> Unit,
     onClickGroupEnter: () -> Unit,
     onClickGroupMake: () -> Unit,
-    onClickSendFcm: () -> Unit,
+    onClickSendFcmButton: (eventId: Long) -> Unit,
     navigateToGroupCreationAndFinish: () -> Unit,
+    onNavigateGallery: () -> Unit,
+    onNavigateVote: () -> Unit,
     viewModel: GroupHomeViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -95,7 +97,9 @@ fun GroupHomeScreen(
                 onClickMyPage = onClickMyPage,
                 onClickGroupEnter = onClickGroupEnter,
                 onClickGroupMake = onClickGroupMake,
-                onClickSendFcm = onClickSendFcm,
+                onClickSendFcmButton = onClickSendFcmButton,
+                onNavigateVote = onNavigateVote,
+                onNavigateGallery = onNavigateGallery,
             )
         }
 


### PR DESCRIPTION
## Issue No
- close #175 

## Overview (Required)
- build 오류 수정 (GroupHomeScreen 인자전달 변경)
