### PR TITLE
[#187] 스플래시 화면 디자인 적용

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/splash/SplashScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/splash/SplashScreen.kt
@@ -1,21 +1,58 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.splash
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.airbnb.lottie.compose.LottieAnimation
+import com.airbnb.lottie.compose.LottieCompositionSpec
+import com.airbnb.lottie.compose.LottieConstants
+import com.airbnb.lottie.compose.animateLottieCompositionAsState
+import com.airbnb.lottie.compose.rememberLottieComposition
+import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
 
 @Composable
 fun SplashScreen() {
-    Box(modifier = Modifier.fillMaxSize()) {
-        Text(
+    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.change_shape))
+    val progress by animateLottieCompositionAsState(
+        composition = composition,
+        iterations = LottieConstants.IterateForever,
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Gray80),
+    ) {
+        StableImage(
             modifier = Modifier
                 .wrapContentSize()
-                .align(Alignment.Center),
-            text = "스플래시 화면입니다",
+                .align(Alignment.TopCenter)
+                .padding(top = 164.dp),
+            drawableResId = R.drawable.ic_pic_title_logo,
+            contentDescription = stringResource(R.string.login_intro_title),
+            colorFilter = ColorFilter.tint(Gray0),
+        )
+        LottieAnimation(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .align(Alignment.Center)
+                .padding(horizontal = 114.dp),
+            composition = composition,
+            progress = { progress },
         )
     }
 }


### PR DESCRIPTION
## Issue No
- close #187 

## Overview (Required)
- 스플래시 화면 디자인 적용

## Links
- https://www.figma.com/design/kZd5C2Mgr2NHKYvefeztSu/Design-file?node-id=1641-6843&t=Yyi9wb9QjddZPaUQ-4

## ScreenShots
https://github.com/user-attachments/assets/26ad0915-8155-4878-a375-7189f3387fba


