### PR TITLE
[#189] 그룹 상세 데이터 맵핑

### DIFF
--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/common/Constants.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/common/Constants.kt
@@ -1,5 +1,5 @@
 package com.mashup.gabbangzip.sharedalbum.data.common
 
 object Constants {
-    const val S3_BUCKET_DOMAIN_URl = "https://pic-api-bucket.s3.ap-northeast-2.amazonaws.com/"
+    const val S3_BUCKET_DOMAIN_URL = "https://pic-api-bucket.s3.ap-northeast-2.amazonaws.com/"
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/common/S3Ext.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/common/S3Ext.kt
@@ -1,0 +1,3 @@
+package com.mashup.gabbangzip.sharedalbum.data.common
+
+fun String.toS3Url() = Constants.S3_BUCKET_DOMAIN_URl + this

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/common/S3Ext.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/common/S3Ext.kt
@@ -1,3 +1,3 @@
 package com.mashup.gabbangzip.sharedalbum.data.common
 
-fun String.toS3Url() = Constants.S3_BUCKET_DOMAIN_URl + this
+fun String.toS3Url() = Constants.S3_BUCKET_DOMAIN_URL + this

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/CardBackImageResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/CardBackImageResponse.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.data.dto.response.group
 
+import com.mashup.gabbangzip.sharedalbum.data.common.toS3Url
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.CardBackImageDomainModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -15,6 +16,6 @@ data class CardBackImageResponse(
 fun CardBackImageResponse.toDomainModel(): CardBackImageDomainModel {
     return CardBackImageDomainModel(
         frameType = frameType,
-        imageUrl = imageUrl,
+        imageUrl = imageUrl.toS3Url(),
     )
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/GroupDetailResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/GroupDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.data.dto.response.group
 
+import com.mashup.gabbangzip.sharedalbum.data.common.toS3Url
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.GroupDomainModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -30,7 +31,7 @@ fun GroupDetailResponse.toDomainModel(): GroupDomainModel {
     return GroupDomainModel(
         id = id,
         cardBackImages = cardBackImages?.map { it.toDomainModel() } ?: emptyList(),
-        cardFrontImageUrl = cardFrontImageUrl,
+        cardFrontImageUrl = cardFrontImageUrl.toS3Url(),
         keyword = keyword,
         name = name,
         recentEvent = recentEvent.toDomainModel(),

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/GroupResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/dto/response/group/GroupResponse.kt
@@ -1,5 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.data.dto.response.group
 
+import com.mashup.gabbangzip.sharedalbum.data.common.toS3Url
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.GroupDomainModel
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
@@ -28,7 +29,7 @@ fun GroupResponse.toDomainModel(): GroupDomainModel {
     return GroupDomainModel(
         id = id,
         cardBackImages = cardBackImages?.map { it.toDomainModel() } ?: emptyList(),
-        cardFrontImageUrl = cardFrontImageUrl,
+        cardFrontImageUrl = cardFrontImageUrl.toS3Url(),
         keyword = keyword,
         name = name,
         recentEvent = recentEvent.toDomainModel(),

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.data.repository
 
 import com.mashup.gabbangzip.sharedalbum.data.base.callApi
-import com.mashup.gabbangzip.sharedalbum.data.common.Constants
+import com.mashup.gabbangzip.sharedalbum.data.common.toS3Url
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.CreateGroupRequest
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.EnterGroupRequest
 import com.mashup.gabbangzip.sharedalbum.data.dto.response.group.toDomainModel
@@ -28,7 +28,7 @@ class GroupRepositoryImpl @Inject constructor(
                 id = id,
                 name = groupName,
                 keyword = keyword,
-                imageUrl = "${Constants.S3_BUCKET_DOMAIN_URL}$groupImageUrl",
+                imageUrl = groupImageUrl.toS3Url(),
                 invitationCode = invitationCode,
             )
         }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
@@ -28,7 +28,7 @@ class GroupRepositoryImpl @Inject constructor(
                 id = id,
                 name = groupName,
                 keyword = keyword,
-                imageUrl = "${Constants.S3_BUCKET_DOMAIN_URl}$groupImageUrl",
+                imageUrl = "${Constants.S3_BUCKET_DOMAIN_URL}$groupImageUrl",
                 invitationCode = invitationCode,
             )
         }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -2,6 +2,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
 import android.graphics.Bitmap
 import android.graphics.Picture
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,6 +55,7 @@ fun RecentEventContainer(
     onClickActionButton: (GroupStatusType) -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
+    Log.d("TAG", "RecentEventContainer: status: $status")
     if (status == GroupStatusType.EVENT_COMPLETED) {
         CompletedEventContainer(
             modifier = modifier,
@@ -73,6 +75,7 @@ fun RecentEventContainer(
                 imageUrl = cardFrontImageUrl,
             )
             status.getActionButtonState()?.let { buttonState ->
+                Log.d("TAG", "RecentEventContainer: $buttonState")
                 RecentEventBottomSection(
                     modifier = Modifier.padding(top = 32.dp),
                     buttonState = buttonState,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.toUiModel
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.toUiModel
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.navigation.MainRoute
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -46,6 +47,7 @@ class GroupDetailViewModel @Inject constructor(
                         state.copy(
                             isLoading = false,
                             groupInfo = groupDetail.toUiModel(),
+                            status = GroupStatusType.getType(groupDetail.status),
                             recentEvent = groupDetail.recentEvent.toUiModel(),
                         )
                     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/GroupEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/GroupEvent.kt
@@ -1,6 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model
 
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.RecentEventDomainModel
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.LocalDateUtil
 
 data class GroupEvent(
     val id: Long,
@@ -13,7 +14,9 @@ fun RecentEventDomainModel.toUiModel(): GroupEvent {
     return GroupEvent(
         id = id,
         title = title.orEmpty(),
-        date = date.toString(),
-        deadline = deadline?.toString().orEmpty(),
+        date = date?.let { LocalDateUtil.format(it) }.orEmpty(),
+        deadline = deadline?.let {
+            LocalDateUtil.format(it, "M월 d일 EEEE hh시 mm분") + " PIC 종료"
+        }.orEmpty(),
     )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/LocalDateUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/LocalDateUtil.kt
@@ -4,6 +4,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 object LocalDateUtil {
     fun getNowDate(): String {
@@ -14,6 +15,6 @@ object LocalDateUtil {
     fun format(date: LocalDateTime, pattern: String = "yyyy.MM.dd"): String {
         return date
             .atZone(ZoneId.of("Asia/Seoul"))
-            .format(DateTimeFormatter.ofPattern(pattern))
+            .format(DateTimeFormatter.ofPattern(pattern, Locale.KOREAN))
     }
 }


### PR DESCRIPTION
## Issue No
- close #189 

## Overview (Required)
- 데이터 형식 UI 요구사항에 맞게 수정 완료입니당
- 서버에서 주는 이미지 URL이 앞에 url 을 추가해야 하는 번거로움이 있는데 확장함수로 하나 빼서 그룹상세, 그룹조회 적용 완료입니당

## Screenshot
<img width="327" alt="스크린샷 2024-08-16 오전 12 46 28" src="https://github.com/user-attachments/assets/a5292c7e-ae9f-4378-9d83-b3e168376528">
<br />
<img width="368" alt="스크린샷 2024-08-16 오전 12 46 15" src="https://github.com/user-attachments/assets/484cc272-575f-40aa-9908-8e0880a47087">
