### PR TITLE
[#196] 역대 이벤트, 진행 중 이벤트 모두 없을 때 그룹상세 이동 제한

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -325,8 +325,9 @@ private fun GroupTag(
     Row(modifier = modifier) {
         PicTag(
             modifier = Modifier.padding(end = 6.dp),
-            text = keyword.name,
+            text = stringResource(id = keyword.tagNameResId),
             iconRes = keyword.symbolResId,
+            iconColor = keyword.symbolColor,
         )
         PicTag(
             text = statusDesc,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -183,7 +183,11 @@ private fun GroupContainer(
     onNavigateGallery: (eventId: Long) -> Unit,
 ) {
     Column(
-        modifier = modifier.noRippleClickable { onGroupDetailClick(groupInfo.id) },
+        modifier = modifier.noRippleClickable {
+            if (groupInfo.status != GroupStatusType.NO_PAST_AND_CURRENT_EVENT) {
+                onGroupDetailClick(groupInfo.id)
+            }
+        },
     ) {
         GroupTitle(
             modifier = Modifier

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -190,6 +190,7 @@ private fun GroupContainer(
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp),
             groupName = groupInfo.name,
+            isVisibleNavigation = groupInfo.status != GroupStatusType.NO_PAST_AND_CURRENT_EVENT,
         )
 
         GroupTag(
@@ -287,7 +288,11 @@ private fun GroupCard(modifier: Modifier, groupInfo: GroupInfo, onClickEventMake
 }
 
 @Composable
-private fun GroupTitle(modifier: Modifier, groupName: String) {
+private fun GroupTitle(
+    modifier: Modifier,
+    groupName: String,
+    isVisibleNavigation: Boolean,
+) {
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -298,10 +303,12 @@ private fun GroupTitle(modifier: Modifier, groupName: String) {
             color = Gray80,
             style = PicTypography.headBold24,
         )
-        Image(
-            painter = painterResource(id = R.drawable.ic_right_arrow),
-            contentDescription = stringResource(R.string.detail_page_move),
-        )
+        if (isVisibleNavigation) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_right_arrow),
+                contentDescription = stringResource(R.string.detail_page_move),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Issue No
- close #196 

## Overview (Required)
- 역대 이벤트, 진행 중 이벤트 모두 없는 경우
   - 그룹상세 이동 제한
   - 네비게이션 아이콘 숨김
- 수정하는 김에 그룹 키워드 태그 UI 요구사항에 맞게 데이터 맵핑

## Screenshot
<img width="346" alt="스크린샷 2024-08-17 오전 11 07 36" src="https://github.com/user-attachments/assets/e958f652-b48b-40d6-a1ba-c4ff7bfe0a68">

