### PR TITLE
[#172] 그룹상세 네컷사진이 만들어졌어요 프레임

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -3,11 +3,17 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -17,13 +23,16 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.GroupInfo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
 
 @Composable
@@ -50,7 +59,7 @@ fun PicPhotoCardFrame(
     modifier: Modifier,
     keywordType: GroupKeyword,
     @DrawableRes frameResId: Int,
-    content: @Composable BoxScope.() -> Unit,
+    content: @Composable BoxScope.() -> Unit = {},
 ) {
     Box(
         modifier = modifier
@@ -143,6 +152,32 @@ private fun PicCroppedImageContainer(
             contentScale = ContentScale.FillBounds,
             contentDescription = null,
         )
+    }
+}
+
+@Composable
+fun PicFourPhotoGrid(
+    modifier: Modifier = Modifier,
+    backgroundColor: Color,
+    horizontalSpacing: Dp = (7.94).dp,
+    verticalSpacing: Dp = (7.94).dp,
+    images: ImmutableList<CardBackImage>,
+) {
+    LazyVerticalGrid(
+        modifier = modifier.wrapContentSize(),
+        verticalArrangement = Arrangement.spacedBy(horizontalSpacing),
+        horizontalArrangement = Arrangement.spacedBy(verticalSpacing),
+        columns = GridCells.Fixed(2),
+        userScrollEnabled = false,
+    ) {
+        items(items = images) { image ->
+            PicCroppedPhoto(
+                modifier = Modifier.aspectRatio(1f),
+                imageUrl = image.imageUrl,
+                frameResId = image.frameType.frameResId,
+                backgroundColor = backgroundColor,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -61,9 +61,12 @@ fun RecentEventContainer(
     onClickActionButton: (GroupStatusType) -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
-    if (status == GroupStatusType.EVENT_COMPLETED) {
+    if (status == GroupStatusType.EVENT_COMPLETED
+        || status == GroupStatusType.NO_CURRENT_EVENT
+    ) {
         CompletedEventContainer(
             modifier = modifier,
+            isFirstVisit = status == GroupStatusType.EVENT_COMPLETED,
             keyword = keyword,
             images = images,
             onClickShareButton = onClickShareButton,
@@ -97,11 +100,11 @@ fun RecentEventContainer(
 @Composable
 private fun CompletedEventContainer(
     modifier: Modifier = Modifier,
+    isFirstVisit: Boolean,
     keyword: GroupKeyword,
     images: ImmutableList<CardBackImage>,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
-    val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.lottie_confetti))
 
     Box(
         modifier = modifier,
@@ -110,14 +113,16 @@ private fun CompletedEventContainer(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Text(
-                text = stringResource(id = R.string.group_detail_event_complete),
-                fontFamily = pretendard,
-                fontWeight = FontWeight.Normal,
-                fontSize = 20.sp,
-                lineHeight = 28.sp,
-                letterSpacing = (-0.02).em,
-            )
+            if (isFirstVisit) {
+                Text(
+                    text = stringResource(id = R.string.group_detail_event_complete),
+                    fontFamily = pretendard,
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 20.sp,
+                    lineHeight = 28.sp,
+                    letterSpacing = (-0.02).em,
+                )
+            }
             PhotoCardWithShareButton(
                 modifier = Modifier.fillMaxWidth(),
                 keyword = keyword,
@@ -125,10 +130,14 @@ private fun CompletedEventContainer(
                 onClickShareButton = onClickShareButton,
             )
         }
-        LottieAnimation(
-            alignment = Alignment.TopCenter,
-            composition = composition,
-        )
+        if (isFirstVisit) {
+            val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.lottie_confetti))
+
+            LottieAnimation(
+                alignment = Alignment.TopCenter,
+                composition = composition,
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -2,20 +2,22 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
 import android.graphics.Bitmap
 import android.graphics.Picture
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,14 +35,18 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.pretendard
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicFourPhotoGrid
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicPhotoCardFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.preview.GroupStatusProvider
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.GroupEvent
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.GroupEventActionButtonState
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.getActionButtonState
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.captureIntoCanvas
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.createBitmap
 
@@ -51,12 +57,15 @@ fun RecentEventContainer(
     event: GroupEvent,
     keyword: GroupKeyword,
     cardFrontImageUrl: String,
+    images: ImmutableList<CardBackImage>,
     onClickActionButton: (GroupStatusType) -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
     if (status == GroupStatusType.EVENT_COMPLETED) {
         CompletedEventContainer(
             modifier = modifier,
+            keyword = keyword,
+            images = images,
             onClickShareButton = onClickShareButton,
         )
     } else {
@@ -88,6 +97,8 @@ fun RecentEventContainer(
 @Composable
 private fun CompletedEventContainer(
     modifier: Modifier = Modifier,
+    keyword: GroupKeyword,
+    images: ImmutableList<CardBackImage>,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
     val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.lottie_confetti))
@@ -108,6 +119,9 @@ private fun CompletedEventContainer(
                 letterSpacing = (-0.02).em,
             )
             PhotoCardWithShareButton(
+                modifier = Modifier.fillMaxWidth(),
+                keyword = keyword,
+                images = images,
                 onClickShareButton = onClickShareButton,
             )
         }
@@ -121,16 +135,26 @@ private fun CompletedEventContainer(
 @Composable
 private fun PhotoCardWithShareButton(
     modifier: Modifier = Modifier,
+    keyword: GroupKeyword,
+    images: ImmutableList<CardBackImage>,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
     val picture = remember { Picture() }
 
     Column(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         PhotoCard(
-            modifier = Modifier.captureIntoCanvas(picture),
+            modifier = Modifier
+                .padding(
+                    top = 16.dp,
+                    start = 41.5.dp,
+                    end = 41.5.dp,
+                )
+                .captureIntoCanvas(picture),
+            keyword = keyword,
+            images = images,
         )
         PicNormalButton(
             modifier = Modifier.padding(top = 32.dp),
@@ -146,14 +170,29 @@ private fun PhotoCardWithShareButton(
 @Composable
 private fun PhotoCard(
     modifier: Modifier = Modifier,
+    keyword: GroupKeyword,
+    images: ImmutableList<CardBackImage>,
 ) {
-    // todo
+    val maxHeight = LocalConfiguration.current.screenHeightDp.dp.div(2)
+
     Box(
         modifier = modifier
-            .padding(top = 16.dp)
-            .size(240.dp)
-            .background(color = Gray60),
-    )
+            .heightIn(max = maxHeight)
+            .wrapContentSize(),
+    ) {
+        PicPhotoCardFrame(
+            modifier = Modifier.matchParentSize(),
+            keywordType = keyword,
+            frameResId = PicPhotoFrame.getTypeByKeyword(keyword.name).frameResId,
+        )
+        PicFourPhotoGrid(
+            modifier = Modifier
+                .padding(top = 74.dp, bottom = 96.dp, start = 30.dp, end = 30.dp)
+                .align(Alignment.Center),
+            backgroundColor = keyword.frontCardBackgroundColor,
+            images = images,
+        )
+    }
 }
 
 @Composable
@@ -229,6 +268,26 @@ private fun RecentEventPreview(
             ),
             keyword = GroupKeyword.SCHOOL,
             cardFrontImageUrl = "https://picsum.photos/200/300",
+            images = ImmutableList(
+                listOf(
+                    CardBackImage(
+                        imageUrl = "https://picsum.photos/200/300",
+                        frameType = PicPhotoFrame.HAMBURGER,
+                    ),
+                    CardBackImage(
+                        imageUrl = "https://picsum.photos/200/300",
+                        frameType = PicPhotoFrame.PLUS,
+                    ),
+                    CardBackImage(
+                        imageUrl = "https://picsum.photos/200/300",
+                        frameType = PicPhotoFrame.GHOST,
+                    ),
+                    CardBackImage(
+                        imageUrl = "https://picsum.photos/200/300",
+                        frameType = PicPhotoFrame.SEXY,
+                    ),
+                ),
+            ),
             onClickActionButton = {},
             onClickShareButton = {},
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -2,7 +2,6 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
 import android.graphics.Bitmap
 import android.graphics.Picture
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -55,7 +54,6 @@ fun RecentEventContainer(
     onClickActionButton: (GroupStatusType) -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
-    Log.d("TAG", "RecentEventContainer: status: $status")
     if (status == GroupStatusType.EVENT_COMPLETED) {
         CompletedEventContainer(
             modifier = modifier,
@@ -75,7 +73,6 @@ fun RecentEventContainer(
                 imageUrl = cardFrontImageUrl,
             )
             status.getActionButtonState()?.let { buttonState ->
-                Log.d("TAG", "RecentEventContainer: $buttonState")
                 RecentEventBottomSection(
                     modifier = Modifier.padding(top = 32.dp),
                     buttonState = buttonState,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -99,7 +99,6 @@ private fun CompletedEventContainer(
             modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            val picture = remember { Picture() }
             Text(
                 text = stringResource(id = R.string.group_detail_event_complete),
                 fontFamily = pretendard,
@@ -108,21 +107,38 @@ private fun CompletedEventContainer(
                 lineHeight = 28.sp,
                 letterSpacing = (-0.02).em,
             )
-            PhotoCard(
-                modifier = Modifier.captureIntoCanvas(picture),
-            )
-            PicNormalButton(
-                modifier = Modifier.padding(top = 32.dp),
-                iconRes = R.drawable.ic_share,
-                onButtonClicked = {
-                    val bitmap = picture.createBitmap()
-                    onClickShareButton(bitmap)
-                },
+            PhotoCardWithShareButton(
+                onClickShareButton = onClickShareButton,
             )
         }
         LottieAnimation(
             alignment = Alignment.TopCenter,
             composition = composition,
+        )
+    }
+}
+
+@Composable
+private fun PhotoCardWithShareButton(
+    modifier: Modifier = Modifier,
+    onClickShareButton: (Bitmap) -> Unit,
+) {
+    val picture = remember { Picture() }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        PhotoCard(
+            modifier = Modifier.captureIntoCanvas(picture),
+        )
+        PicNormalButton(
+            modifier = Modifier.padding(top = 32.dp),
+            iconRes = R.drawable.ic_share,
+            onButtonClicked = {
+                val bitmap = picture.createBitmap()
+                onClickShareButton(bitmap)
+            },
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -61,8 +61,8 @@ fun RecentEventContainer(
     onClickActionButton: (GroupStatusType) -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
-    if (status == GroupStatusType.EVENT_COMPLETED
-        || status == GroupStatusType.NO_CURRENT_EVENT
+    if (status == GroupStatusType.EVENT_COMPLETED ||
+        status == GroupStatusType.NO_CURRENT_EVENT
     ) {
         CompletedEventContainer(
             modifier = modifier,
@@ -105,7 +105,6 @@ private fun CompletedEventContainer(
     images: ImmutableList<CardBackImage>,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
-
     Box(
         modifier = modifier,
     ) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -190,8 +190,8 @@ private fun PhotoCard(
 
     Box(
         modifier = modifier
-            .heightIn(max = maxHeight)
-            .wrapContentSize(),
+            .wrapContentSize()
+            .heightIn(max = maxHeight),
     ) {
         PicPhotoCardFrame(
             modifier = Modifier.matchParentSize(),

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -208,14 +208,14 @@ private fun PhotoCard(
         Text(
             modifier = Modifier
                 .align(Alignment.TopCenter)
-                .padding(top = 37.dp),
+                .padding(top = 25.dp),
             text = date,
             color = Gray80,
             style = PicTypography.bodyMedium16,
         )
         PicFourPhotoGrid(
             modifier = Modifier
-                .padding(top = 74.dp, bottom = 96.dp, start = 30.dp, end = 30.dp)
+                .padding(top = 85.dp, bottom = 85.dp, start = 30.dp, end = 30.dp)
                 .align(Alignment.Center),
             backgroundColor = keyword.frontCardBackgroundColor,
             images = images,
@@ -223,7 +223,7 @@ private fun PhotoCard(
         Text(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(top = 31.dp, bottom = 41.dp),
+                .padding(bottom = 31.dp),
             text = title,
             color = Gray80,
             style = PicTypography.headBold20,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -69,6 +69,8 @@ fun RecentEventContainer(
             isFirstVisit = status == GroupStatusType.EVENT_COMPLETED,
             keyword = keyword,
             images = images,
+            date = event.date,
+            title = event.title,
             onClickShareButton = onClickShareButton,
         )
     } else {
@@ -102,6 +104,8 @@ private fun CompletedEventContainer(
     modifier: Modifier = Modifier,
     isFirstVisit: Boolean,
     keyword: GroupKeyword,
+    date: String,
+    title: String,
     images: ImmutableList<CardBackImage>,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
@@ -125,6 +129,8 @@ private fun CompletedEventContainer(
             PhotoCardWithShareButton(
                 modifier = Modifier.fillMaxWidth(),
                 keyword = keyword,
+                date = date,
+                title = title,
                 images = images,
                 onClickShareButton = onClickShareButton,
             )
@@ -144,6 +150,8 @@ private fun CompletedEventContainer(
 private fun PhotoCardWithShareButton(
     modifier: Modifier = Modifier,
     keyword: GroupKeyword,
+    date: String,
+    title: String,
     images: ImmutableList<CardBackImage>,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
@@ -162,6 +170,8 @@ private fun PhotoCardWithShareButton(
                 )
                 .captureIntoCanvas(picture),
             keyword = keyword,
+            date = date,
+            title = title,
             images = images,
         )
         PicNormalButton(
@@ -179,6 +189,8 @@ private fun PhotoCardWithShareButton(
 private fun PhotoCard(
     modifier: Modifier = Modifier,
     keyword: GroupKeyword,
+    date: String,
+    title: String,
     images: ImmutableList<CardBackImage>,
 ) {
     val maxHeight = LocalConfiguration.current.screenHeightDp.dp.div(2)
@@ -193,12 +205,28 @@ private fun PhotoCard(
             keywordType = keyword,
             frameResId = PicPhotoFrame.getTypeByKeyword(keyword.name).frameResId,
         )
+        Text(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 37.dp),
+            text = date,
+            color = Gray80,
+            style = PicTypography.bodyMedium16,
+        )
         PicFourPhotoGrid(
             modifier = Modifier
                 .padding(top = 74.dp, bottom = 96.dp, start = 30.dp, end = 30.dp)
                 .align(Alignment.Center),
             backgroundColor = keyword.frontCardBackgroundColor,
             images = images,
+        )
+        Text(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(top = 31.dp, bottom = 41.dp),
+            text = title,
+            color = Gray80,
+            style = PicTypography.headBold20,
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -19,12 +19,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
 import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.rememberLottieComposition
@@ -33,7 +30,6 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.pretendard
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicFourPhotoGrid
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
@@ -119,11 +115,8 @@ private fun CompletedEventContainer(
             if (isFirstVisit) {
                 Text(
                     text = stringResource(id = R.string.group_detail_event_complete),
-                    fontFamily = pretendard,
-                    fontWeight = FontWeight.Normal,
-                    fontSize = 20.sp,
-                    lineHeight = 28.sp,
-                    letterSpacing = (-0.02).em,
+                    style = PicTypography.headBold20,
+                    color = Gray80,
                 )
             }
             PhotoCardWithShareButton(

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -31,6 +31,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.Gr
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupStatusType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 
 @Composable
 fun GroupDetailScreen(
@@ -70,6 +71,7 @@ fun GroupDetailScreen(
                 GroupStatusType.BEFORE_MY_UPLOAD -> state.recentEvent?.let { event ->
                     onClickOpenPhotoPickerButton(event.id)
                 }
+
                 GroupStatusType.AFTER_MY_UPLOAD, GroupStatusType.AFTER_MY_VOTE -> {
                     state.recentEvent
                         ?.let {
@@ -172,6 +174,7 @@ private fun GroupDetailScreenContent(
                 event = state.recentEvent,
                 keyword = state.groupInfo?.keyword ?: GroupKeyword.SCHOOL,
                 cardFrontImageUrl = state.groupInfo?.cardFrontImageUrl.orEmpty(),
+                images = ImmutableList(state.groupInfo?.cardBackImages.orEmpty()),
                 onClickActionButton = onClickActionButton,
                 onClickShareButton = onClickShareButton,
             )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailViewModel.kt
@@ -51,6 +51,7 @@ class GroupDetailViewModel @Inject constructor(
                             groupInfo = groupDetail.toUiModel(),
                             status = GroupStatusType.getType(groupDetail.status),
                             recentEvent = groupDetail.recentEvent.toUiModel(),
+                            history = groupDetail.history.map { it.toUiModel() },
                         )
                     }
                 }.onFailure {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -100,13 +100,13 @@
     <string name="group_detail_empty_history_label">네컷 사진이 만들어지면\n이벤트가 추가돼요.</string>
 
     <string name="button_text_state_before_my_upload">내 PIC 올리기</string>
-    <string name="information_text_state_before_my_upload">까지 내 PIC 등록을 완료해 주세요.</string>
+    <string name="information_text_state_before_my_upload">모든 그룹원이 사진을 올리면 투표가 시작돼요</string>
     <string name="button_text_state_after_my_upload">쿡 찌르기</string>
-    <string name="information_text_state_after_my_upload">아직 사진 추가를 하지 않은 친구가 있어요!</string>
+    <string name="information_text_state_after_my_upload">아직 사진 추가를 하지 않은 친구가 있어요</string>
     <string name="button_text_state_before_my_vote">투표하기</string>
-    <string name="information_text_state_before_my_vote">내 PIC을 고르고 네컷사진을 완성해 보세요.</string>
+    <string name="information_text_state_before_my_vote">내 PIC을 고르고 네컷사진을 완성해 보세요</string>
     <string name="button_text_state_after_my_vote">쿡 찌르기</string>
-    <string name="information_text_state_after_my_vote">아직 PIC을 고르지 않은 친구가 있어요!</string>
+    <string name="information_text_state_after_my_vote">아직 PIC 하지 않은 친구가 있어요</string>
 
     <string name="complete">완료</string>
     <string name="group_complete_title">그룹에 친구들을 추가하고\n추억을 함께 PIC 해보세요</string>


### PR DESCRIPTION
## Issue No
- close #172 

## Overview (Required)
- 그룹상세 네컷사진이 만들어졌어요 프레임 적용
- NO_CURRENT_EVENT, EVENT_COMPLETE 일 때 공유 기능 활성화
- 좀만 더하면 포토카드 일반화가 가능할지도?

## Screenshot
<img width="544" alt="스크린샷 2024-08-17 오후 4 37 21" src="https://github.com/user-attachments/assets/68511248-7a7f-4a51-9e6c-4fa99c417abd">

