### PR TITLE
[#159] 그룹 생성하기 완료 화면 내 링크 복사 버튼 잘림

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/GroupCreationScaffold.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/GroupCreationScaffold.kt
@@ -37,7 +37,7 @@ fun GroupCreationScaffold(
             )
             Box(
                 modifier = Modifier.align(Alignment.BottomCenter),
-                content = bottomFloatingButton
+                content = bottomFloatingButton,
             )
         }
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/GroupCreationScaffold.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/GroupCreationScaffold.kt
@@ -1,0 +1,44 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun GroupCreationScaffold(
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment.Horizontal = Alignment.Start,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    content: @Composable ColumnScope.() -> Unit,
+    topBar: @Composable () -> Unit = {},
+    bottomFloatingButton: @Composable BoxScope.() -> Unit = {},
+) {
+    val scrollState = rememberScrollState()
+    Column(modifier = modifier) {
+        topBar()
+        Box(modifier = Modifier.weight(1f)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding)
+                    .verticalScroll(scrollState),
+                horizontalAlignment = contentAlignment,
+                content = content,
+            )
+            Box(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                content = bottomFloatingButton
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/GroupCreationScaffold.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/GroupCreationScaffold.kt
@@ -24,17 +24,53 @@ fun GroupCreationScaffold(
     bottomFloatingButton: @Composable BoxScope.() -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
+    GroupCreationInternals(
+        modifier = modifier,
+        topBar = topBar,
+        bottomFloatingButton = bottomFloatingButton,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(contentPadding)
+                .verticalScroll(scrollState),
+            horizontalAlignment = contentAlignment,
+            content = content,
+        )
+    }
+}
+
+@Composable
+fun GroupCreationScaffold(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    boxContent: @Composable BoxScope.() -> Unit,
+    topBar: @Composable () -> Unit = {},
+    bottomFloatingButton: @Composable BoxScope.() -> Unit = {},
+) {
+    GroupCreationInternals(
+        modifier = modifier,
+        topBar = topBar,
+        bottomFloatingButton = bottomFloatingButton,
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize().padding(contentPadding),
+            content = boxContent,
+        )
+    }
+}
+
+@Composable
+private fun GroupCreationInternals(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomFloatingButton: @Composable BoxScope.() -> Unit = {},
+    content: @Composable () -> Unit,
+) {
     Column(modifier = modifier) {
         topBar()
         Box(modifier = Modifier.weight(1f)) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(contentPadding)
-                    .verticalScroll(scrollState),
-                horizontalAlignment = contentAlignment,
-                content = content,
-            )
+            content()
             Box(
                 modifier = Modifier.align(Alignment.BottomCenter),
                 content = bottomFloatingButton,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -83,8 +83,8 @@ fun GroupCreationCompleteScreen(
             )
             Spacer(
                 modifier = Modifier
-                .fillMaxWidth()
-                .height(60.dp)
+                    .fillMaxWidth()
+                    .height(60.dp),
             )
         },
     )
@@ -168,9 +168,11 @@ private fun ThumbnailCard(
 
 @Composable
 private fun ColumnScope.EmptyThumbnailCard() {
-    Box(modifier = Modifier
-        .size(310.dp, 420.dp)
-        .align(Alignment.CenterHorizontally))
+    Box(
+        modifier = Modifier
+            .size(310.dp, 420.dp)
+            .align(Alignment.CenterHorizontally),
+    )
 }
 
 @Preview(showBackground = true)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -2,7 +2,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -30,6 +31,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicProgressBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextOnlyTopBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common.GroupCreationScaffold
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common.ThumbnailCardFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.model.GroupCreationResult
 
@@ -39,23 +41,15 @@ fun GroupCreationCompleteScreen(
     onNextButtonClicked: () -> Unit,
     showSnackBarMessage: (type: PicSnackbarType, message: String) -> Unit,
 ) {
-    val clipboardManager = LocalClipboardManager.current
-    val copyLinkMessage = stringResource(id = R.string.button_copy_link_message)
-    val invitationMessage = stringResource(id = R.string.invitation_message)
-    val playStoreUrl = stringResource(id = R.string.play_store_url)
-    val appStoreUrl = stringResource(id = R.string.app_store_url)
-    Column {
-        PicTextOnlyTopBar(
-            modifier = Modifier
-                .background(Gray0Alpha80)
-                .padding(top = 20.dp),
-            titleText = stringResource(id = R.string.complete),
-        )
-        Column(
-            modifier = Modifier
-                .weight(1f),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+    GroupCreationScaffold(
+        contentAlignment = Alignment.CenterHorizontally,
+        topBar = {
+            PicTextOnlyTopBar(
+                modifier = Modifier
+                    .background(Gray0Alpha80)
+                    .padding(top = 20.dp),
+                titleText = stringResource(id = R.string.complete),
+            )
             PicProgressBar(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -64,61 +58,86 @@ fun GroupCreationCompleteScreen(
                 level = 4,
                 total = 4f,
             )
-            Text(
+        },
+        bottomFloatingButton = {
+            PicButton(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .wrapContentHeight()
-                    .padding(bottom = 16.dp),
-                text = stringResource(id = R.string.group_complete_title),
-                style = PicTypography.headBold18,
-                color = Gray80,
-                textAlign = TextAlign.Center,
-            )
-            if (groupCreationResult != null) {
-                ThumbnailCard(
-                    modifier = Modifier.size(310.dp, 420.dp),
-                    groupCreationResult = groupCreationResult,
-                )
-            } else {
-                EmptyThumbnailCard()
-            }
-            Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-                    .padding(top = 16.dp, bottom = 8.dp),
-                text = stringResource(id = R.string.group_complete_contents),
-                style = PicTypography.bodyMedium14,
-                color = Gray60,
-                textAlign = TextAlign.Center,
-            )
-            PicNormalButton(
-                text = stringResource(id = R.string.button_copy_link),
+                    .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
+                text = stringResource(id = R.string.complete),
                 isRippleClickable = true,
-                backgroundColor = Gray40,
-                contentColor = Gray80,
-                iconRes = R.drawable.ic_link,
-                onButtonClicked = {
-                    groupCreationResult?.invitationCode?.let { invitationCode ->
-                        showSnackBarMessage(PicSnackbarType.CHECK, copyLinkMessage)
-                        clipboardManager.setText(
-                            AnnotatedString(
-                                invitationMessage.format(playStoreUrl, appStoreUrl, invitationCode),
-                            ),
-                        )
-                    }
-                },
+                onButtonClicked = onNextButtonClicked,
             )
-        }
-        PicButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
-            text = stringResource(id = R.string.complete),
-            isRippleClickable = true,
-            onButtonClicked = onNextButtonClicked,
+        },
+        content = {
+            GroupCreationCompleteContent(
+                clipboardManager = LocalClipboardManager.current,
+                copyLinkMessage = stringResource(id = R.string.button_copy_link_message),
+                invitationMessage = stringResource(id = R.string.invitation_message),
+                playStoreUrl = stringResource(id = R.string.play_store_url),
+                appStoreUrl = stringResource(id = R.string.app_store_url),
+                groupCreationResult = groupCreationResult,
+                showSnackBarMessage = showSnackBarMessage
+            )
+        },
+    )
+}
+
+@Composable
+private fun ColumnScope.GroupCreationCompleteContent(
+    groupCreationResult: GroupCreationResult?,
+    clipboardManager: ClipboardManager,
+    copyLinkMessage: String,
+    invitationMessage: String,
+    playStoreUrl: String,
+    appStoreUrl: String,
+    showSnackBarMessage: (type: PicSnackbarType, message: String) -> Unit,
+) {
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(bottom = 16.dp),
+        text = stringResource(id = R.string.group_complete_title),
+        style = PicTypography.headBold18,
+        color = Gray80,
+        textAlign = TextAlign.Center,
+    )
+    if (groupCreationResult != null) {
+        ThumbnailCard(
+            modifier = Modifier.size(310.dp, 420.dp),
+            groupCreationResult = groupCreationResult,
         )
+    } else {
+        EmptyThumbnailCard()
     }
+    Text(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(top = 16.dp, bottom = 8.dp),
+        text = stringResource(id = R.string.group_complete_contents),
+        style = PicTypography.bodyMedium14,
+        color = Gray60,
+        textAlign = TextAlign.Center,
+    )
+    PicNormalButton(
+        text = stringResource(id = R.string.button_copy_link),
+        isRippleClickable = true,
+        backgroundColor = Gray40,
+        contentColor = Gray80,
+        iconRes = R.drawable.ic_link,
+        onButtonClicked = {
+            groupCreationResult?.invitationCode?.let { invitationCode ->
+                showSnackBarMessage(PicSnackbarType.CHECK, copyLinkMessage)
+                clipboardManager.setText(
+                    AnnotatedString(
+                        invitationMessage.format(playStoreUrl, appStoreUrl, invitationCode),
+                    ),
+                )
+            }
+        },
+    )
 }
 
 @Composable
@@ -141,8 +160,10 @@ private fun ThumbnailCard(
 }
 
 @Composable
-private fun EmptyThumbnailCard() {
-    Box(modifier = Modifier.size(310.dp, 420.dp))
+private fun ColumnScope.EmptyThumbnailCard() {
+    Box(modifier = Modifier
+        .size(310.dp, 420.dp)
+        .align(Alignment.CenterHorizontally))
 }
 
 @Preview(showBackground = true)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -56,7 +56,7 @@ fun GroupCreationCompleteScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight()
-                    .padding(top = 3.dp, bottom = 32.dp, start = 16.dp, end = 16.dp),
+                    .padding(top = 3.dp, start = 16.dp, end = 16.dp),
                 level = 4,
                 total = 4f,
             )
@@ -104,7 +104,7 @@ private fun ColumnScope.GroupCreationCompleteContent(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .padding(bottom = 16.dp),
+            .padding(top = 32.dp, bottom = 16.dp),
         text = stringResource(id = R.string.group_complete_title),
         style = PicTypography.headBold18,
         color = Gray80,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -3,7 +3,9 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -77,7 +79,12 @@ fun GroupCreationCompleteScreen(
                 playStoreUrl = stringResource(id = R.string.play_store_url),
                 appStoreUrl = stringResource(id = R.string.app_store_url),
                 groupCreationResult = groupCreationResult,
-                showSnackBarMessage = showSnackBarMessage
+                showSnackBarMessage = showSnackBarMessage,
+            )
+            Spacer(
+                modifier = Modifier
+                .fillMaxWidth()
+                .height(60.dp)
             )
         },
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/intro/GroupCreationIntroScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/intro/GroupCreationIntroScreen.kt
@@ -110,7 +110,7 @@ fun GroupCreationIntroScreen(
 
 @Preview(showBackground = true)
 @Composable
-private fun GroupCreationFirstScreenPreview() {
+private fun GroupCreationIntroScreenPreview() {
     GroupCreationIntroScreen(
         onClickEnterByCodeButton = {},
         onClickNextButton = {},

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -3,7 +3,9 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.keyword
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -79,6 +81,11 @@ private fun GroupCreationKeywordScreen(
             GroupCreationCompleteContent(
                 selectedKeyword = selectedKeyword,
                 setSelected = setSelected
+            )
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
             )
         },
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -2,7 +2,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.keyword
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -25,6 +26,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicBackButtonTop
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicKeywordButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicProgressBar
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common.GroupCreationScaffold
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 
 @Composable
@@ -34,56 +36,77 @@ fun GroupCreationKeywordScreen(
     onNextButtonClicked: (keyword: GroupKeyword) -> Unit,
 ) {
     val (selectedKeyword, setSelected) = remember { mutableStateOf(initialKeyword) }
+    GroupCreationKeywordScreen(selectedKeyword, setSelected, onBackButtonClicked, onNextButtonClicked)
+}
 
-    Column {
-        PicBackButtonTopBar(
-            modifier = Modifier
-                .background(Gray0Alpha80)
-                .padding(top = 16.dp),
-            titleText = stringResource(id = R.string.group_creation_button_name),
-            backButtonClicked = onBackButtonClicked,
-        )
-        Column(
-            modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .weight(1f),
-        ) {
+@Composable
+private fun GroupCreationKeywordScreen(
+    selectedKeyword: GroupKeyword,
+    setSelected: (GroupKeyword) -> Unit,
+    onBackButtonClicked: () -> Unit,
+    onNextButtonClicked: (keyword: GroupKeyword) -> Unit,
+) {
+    GroupCreationScaffold(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        topBar = {
+            PicBackButtonTopBar(
+                modifier = Modifier
+                    .background(Gray0Alpha80)
+                    .padding(top = 16.dp),
+                titleText = "stringResource(id = R.string.group_creation_button_name)",
+                backButtonClicked = onBackButtonClicked,
+            )
             PicProgressBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 32.dp),
+                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp),
                 level = 2,
                 total = 4f,
             )
-            Text(
-                modifier = Modifier.padding(bottom = 24.dp),
-                text = stringResource(id = R.string.group_creation_keyword_title),
-                style = PicTypography.headBold18,
-                color = Gray80,
+        },
+        bottomFloatingButton = {
+            PicButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
+                text = "stringResource(id = R.string.next)",
+                isRippleClickable = true,
+                enable = true,
+                onButtonClicked = { onNextButtonClicked(selectedKeyword) },
             )
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(3),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                items(GroupKeyword.entries) { keyword ->
-                    PicKeywordButton(
-                        keyword = keyword,
-                        selected = selectedKeyword == keyword,
-                        onButtonClicked = { setSelected(it) },
-                    )
-                }
-            }
+        },
+        content = {
+            GroupCreationCompleteContent(
+                selectedKeyword = selectedKeyword,
+                setSelected = setSelected
+            )
+        },
+    )
+}
+
+@Composable
+private fun GroupCreationCompleteContent(
+    selectedKeyword: GroupKeyword,
+    setSelected: (GroupKeyword) -> Unit,
+) {
+    Text(
+        modifier = Modifier.padding(bottom = 24.dp),
+        text = stringResource(id = R.string.group_creation_keyword_title),
+        style = PicTypography.headBold18,
+        color = Gray80,
+    )
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        items(GroupKeyword.entries) { keyword ->
+            PicKeywordButton(
+                keyword = keyword,
+                selected = selectedKeyword == keyword,
+                onButtonClicked = { setSelected(it) },
+            )
         }
-        PicButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
-            text = stringResource(id = R.string.next),
-            isRippleClickable = true,
-            enable = true,
-            onButtonClicked = { onNextButtonClicked(selectedKeyword) },
-        )
     }
 }
 
@@ -92,7 +115,8 @@ fun GroupCreationKeywordScreen(
 fun GroupCreationKeywordScreenPreview() {
     SharedAlbumTheme {
         GroupCreationKeywordScreen(
-            initialKeyword = GroupKeyword.SCHOOL,
+            selectedKeyword = GroupKeyword.SCHOOL,
+            setSelected = {},
             onBackButtonClicked = {},
             onNextButtonClicked = {},
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -83,7 +83,7 @@ private fun GroupCreationKeywordScreen(
             )
         },
         boxContent = {
-            GroupCreationCompleteContent(
+            GroupCreationKeywordContent(
                 selectedKeyword = selectedKeyword,
                 setSelected = setSelected,
             )
@@ -92,7 +92,7 @@ private fun GroupCreationKeywordScreen(
 }
 
 @Composable
-private fun GroupCreationCompleteContent(
+private fun GroupCreationKeywordContent(
     selectedKeyword: GroupKeyword,
     setSelected: (GroupKeyword) -> Unit,
 ) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -38,7 +37,12 @@ fun GroupCreationKeywordScreen(
     onNextButtonClicked: (keyword: GroupKeyword) -> Unit,
 ) {
     val (selectedKeyword, setSelected) = remember { mutableStateOf(initialKeyword) }
-    GroupCreationKeywordScreen(selectedKeyword, setSelected, onBackButtonClicked, onNextButtonClicked)
+    GroupCreationKeywordScreen(
+        selectedKeyword,
+        setSelected,
+        onBackButtonClicked,
+        onNextButtonClicked,
+    )
 }
 
 @Composable
@@ -80,12 +84,12 @@ private fun GroupCreationKeywordScreen(
         content = {
             GroupCreationCompleteContent(
                 selectedKeyword = selectedKeyword,
-                setSelected = setSelected
+                setSelected = setSelected,
             )
             Spacer(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(60.dp)
+                    .height(60.dp),
             )
         },
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -59,7 +59,7 @@ private fun GroupCreationKeywordScreen(
                 modifier = Modifier
                     .background(Gray0Alpha80)
                     .padding(top = 16.dp),
-                titleText = "stringResource(id = R.string.group_creation_button_name)",
+                titleText = stringResource(id = R.string.group_creation_button_name),
                 backButtonClicked = onBackButtonClicked,
             )
             PicProgressBar(
@@ -75,7 +75,7 @@ private fun GroupCreationKeywordScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
-                text = "stringResource(id = R.string.next)",
+                text = stringResource(id = R.string.next),
                 isRippleClickable = true,
                 enable = true,
                 onButtonClicked = { onNextButtonClicked(selectedKeyword) },

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
@@ -65,7 +66,7 @@ private fun GroupCreationKeywordScreen(
             PicProgressBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp),
+                    .padding(start = 16.dp, end = 16.dp),
                 level = 2,
                 total = 4f,
             )
@@ -81,15 +82,10 @@ private fun GroupCreationKeywordScreen(
                 onButtonClicked = { onNextButtonClicked(selectedKeyword) },
             )
         },
-        content = {
+        boxContent = {
             GroupCreationCompleteContent(
                 selectedKeyword = selectedKeyword,
                 setSelected = setSelected,
-            )
-            Spacer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(60.dp),
             )
         },
     )
@@ -100,22 +96,31 @@ private fun GroupCreationCompleteContent(
     selectedKeyword: GroupKeyword,
     setSelected: (GroupKeyword) -> Unit,
 ) {
-    Text(
-        modifier = Modifier.padding(bottom = 24.dp),
-        text = stringResource(id = R.string.group_creation_keyword_title),
-        style = PicTypography.headBold18,
-        color = Gray80,
-    )
     LazyVerticalGrid(
         columns = GridCells.Fixed(3),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
+        item(span = { GridItemSpan(3) }) {
+            Text(
+                modifier = Modifier.padding(top = 32.dp, bottom = 24.dp),
+                text = stringResource(id = R.string.group_creation_keyword_title),
+                style = PicTypography.headBold18,
+                color = Gray80,
+            )
+        }
         items(GroupKeyword.entries) { keyword ->
             PicKeywordButton(
                 keyword = keyword,
                 selected = selectedKeyword == keyword,
                 onButtonClicked = { setSelected(it) },
+            )
+        }
+        item(span = { GridItemSpan(3) }) {
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp),
             )
         }
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
@@ -2,7 +2,9 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.name
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
@@ -98,6 +100,11 @@ private fun GroupCreationNameScreen(
             GroupCreationNameContent(
                 name = name,
                 setName = setName,
+            )
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
             )
         },
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
@@ -77,7 +77,7 @@ private fun GroupCreationNameScreen(
             PicProgressBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp),
+                    .padding(start = 16.dp, end = 16.dp),
                 level = 1,
                 total = 4f,
             )
@@ -117,7 +117,7 @@ private fun GroupCreationNameContent(
     setName: (String) -> Unit,
 ) {
     Text(
-        modifier = Modifier.padding(bottom = 16.dp),
+        modifier = Modifier.padding(top = 32.dp, bottom = 16.dp),
         text = stringResource(id = R.string.group_creation_name_title),
         style = PicTypography.headBold18,
         color = Gray80,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
@@ -1,7 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.name
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -11,8 +11,8 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -26,6 +26,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicBackButtonTop
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicProgressBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextField
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common.GroupCreationScaffold
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.hideKeyboardOnOutsideClicked
 
 @Composable
@@ -35,62 +36,91 @@ fun GroupCreationNameScreen(
     onNextButtonClicked: (name: String) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
-    var name by remember { mutableStateOf(initialName) }
+    val (name, setName) = remember { mutableStateOf(initialName) }
     val buttonEnabled by remember { derivedStateOf { name.isNotBlank() } }
+    GroupCreationNameScreen(
+        name = name,
+        focusManager = focusManager,
+        setName = setName,
+        buttonEnabled = buttonEnabled,
+        onBackButtonClicked = onBackButtonClicked,
+        onNextButtonClicked = onNextButtonClicked,
+    )
+}
 
-    Column(
+@Composable
+private fun GroupCreationNameScreen(
+    name: String,
+    focusManager: FocusManager,
+    buttonEnabled: Boolean,
+    setName: (String) -> Unit,
+    onBackButtonClicked: () -> Unit,
+    onNextButtonClicked: (name: String) -> Unit,
+) {
+    GroupCreationScaffold(
         modifier = Modifier.hideKeyboardOnOutsideClicked(),
-    ) {
-        PicBackButtonTopBar(
-            modifier = Modifier
-                .background(Gray0Alpha80)
-                .padding(top = 16.dp),
-            titleText = stringResource(id = R.string.group_creation_button_name),
-            backButtonClicked = {
-                focusManager.clearFocus()
-                onBackButtonClicked()
-            },
-        )
-        Column(
-            modifier = Modifier
-                .padding(horizontal = 16.dp)
-                .weight(1f),
-        ) {
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        topBar = {
+            PicBackButtonTopBar(
+                modifier = Modifier
+                    .background(Gray0Alpha80)
+                    .padding(top = 16.dp),
+                titleText = stringResource(id = R.string.group_creation_button_name),
+                backButtonClicked = {
+                    focusManager.clearFocus()
+                    onBackButtonClicked()
+                },
+            )
             PicProgressBar(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 32.dp),
+                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp),
                 level = 1,
                 total = 4f,
             )
-            Text(
-                modifier = Modifier.padding(bottom = 16.dp),
-                text = stringResource(id = R.string.group_creation_name_title),
-                style = PicTypography.headBold18,
-                color = Gray80,
+        },
+        bottomFloatingButton = {
+            PicButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .imePadding()
+                    .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
+                text = stringResource(id = R.string.next),
+                isRippleClickable = true,
+                enable = buttonEnabled,
+                onButtonClicked = {
+                    focusManager.clearFocus()
+                    onNextButtonClicked(name)
+                },
             )
-            PicTextField(
-                modifier = Modifier.fillMaxWidth(),
-                value = name,
-                onValueChange = { name = it },
-                hint = stringResource(id = R.string.group_creation_name_hint),
-                maxLength = 10,
+        },
+        content = {
+            GroupCreationNameContent(
+                name = name,
+                setName = setName,
             )
-        }
-        PicButton(
-            modifier = Modifier
-                .fillMaxWidth()
-                .imePadding()
-                .padding(start = 22.dp, end = 22.dp, bottom = 16.dp),
-            text = stringResource(id = R.string.next),
-            isRippleClickable = true,
-            enable = buttonEnabled,
-            onButtonClicked = {
-                focusManager.clearFocus()
-                onNextButtonClicked(name)
-            },
-        )
-    }
+        },
+    )
+}
+
+@Composable
+private fun GroupCreationNameContent(
+    name: String,
+    setName: (String) -> Unit,
+) {
+    Text(
+        modifier = Modifier.padding(bottom = 16.dp),
+        text = stringResource(id = R.string.group_creation_name_title),
+        style = PicTypography.headBold18,
+        color = Gray80,
+    )
+    PicTextField(
+        modifier = Modifier.fillMaxWidth(),
+        value = name,
+        onValueChange = setName,
+        hint = stringResource(id = R.string.group_creation_name_hint),
+        maxLength = 10,
+    )
 }
 
 @Preview(showBackground = true)
@@ -98,7 +128,10 @@ fun GroupCreationNameScreen(
 fun GroupCreationNameScreenPreview() {
     SharedAlbumTheme {
         GroupCreationNameScreen(
-            initialName = "",
+            name = "",
+            focusManager = LocalFocusManager.current,
+            buttonEnabled = false,
+            setName = {},
             onBackButtonClicked = {},
             onNextButtonClicked = {},
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
@@ -104,7 +104,7 @@ private fun GroupCreationNameScreen(
             Spacer(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(60.dp)
+                    .height(60.dp),
             )
         },
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.platform.LocalFocusManager
@@ -38,12 +39,12 @@ fun GroupCreationNameScreen(
     onNextButtonClicked: (name: String) -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
-    val (name, setName) = remember { mutableStateOf(initialName) }
+    var name by remember { mutableStateOf(initialName) }
     val buttonEnabled by remember { derivedStateOf { name.isNotBlank() } }
     GroupCreationNameScreen(
         name = name,
         focusManager = focusManager,
-        setName = setName,
+        setName = { name = it },
         buttonEnabled = buttonEnabled,
         onBackButtonClicked = onBackButtonClicked,
         onNextButtonClicked = onNextButtonClicked,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
@@ -132,7 +132,7 @@ private fun GroupCreationThumbnailScreen(
             Spacer(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(60.dp)
+                    .height(60.dp),
             )
         },
     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
@@ -103,7 +103,7 @@ private fun GroupCreationThumbnailScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentHeight()
-                    .padding(bottom = 32.dp, start = 16.dp, end = 16.dp),
+                    .padding(start = 16.dp, end = 16.dp),
                 level = 3,
                 total = 4f,
             )
@@ -151,7 +151,7 @@ private fun GroupCreationThumbnailContent(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .padding(bottom = 32.dp),
+            .padding(top = 32.dp, bottom = 32.dp),
         text = stringResource(id = R.string.group_add_description),
         style = PicTypography.headBold18,
         color = Gray80,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
@@ -5,7 +5,9 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -126,6 +128,11 @@ private fun GroupCreationThumbnailScreen(
                 modifyButtonEnabled = modifyButtonEnabled,
                 onThumbnailButtonClick = { setModifyButtonEnabled(true) },
                 openPhotoPicker = openPhotoPicker,
+            )
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
             )
         },
     )


### PR DESCRIPTION
## Issue No
- close #159 

## Overview (Required)
- 그룹 생성하기 완료 화면 내 링크 복사 버튼 잘림
- 기타 화면들도 이런 상황에서 스크롤 될 수 있도록 처리 작업 진행
- 그룹 생성관련 화면들 공통로직 GroupCreationScaffold 로 정리 후 적용

## Screenshots
https://github.com/user-attachments/assets/7f135aad-0b0b-4205-97d2-5394dddec1b6

참고) 디바이스의 최소 width 를 조정해서 스크롤 상황이 발생할 수 있도록 강제하여 테스트했습니당
