### PR TITLE
[#210] 완료화면으로 넘어갈 때 backStack 모두 제거

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/navigation/GroupCreationCompleteNavigation.kt
@@ -9,7 +9,11 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.complete.
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.navigation.GroupCreationRoute
 
 fun NavController.navigateToGroupCreationComplete() {
-    navigate(GroupCreationRoute.CompleteScreenRoute.route)
+    navigate(GroupCreationRoute.CompleteScreenRoute.route) {
+        popUpTo(graph.startDestinationId) {
+            inclusive = true
+        }
+    }
 }
 
 fun NavGraphBuilder.groupCreationCompleteNavGraph(


### PR DESCRIPTION
## Issue No
- close #210 

## Overview (Required)
- 그룹 생성 완료화면에서 뒤로가기 누르면 이전 UI 잠깐 뜸

## Screenshot
https://github.com/user-attachments/assets/24a4b8b7-0f19-4271-9e19-e60e2201b694

-> 이제 뒤로가기 하면 "완료" 버튼을 누른것과 동일하게 동작한다.
