### PR TITLE
[#204] 그룹상세 스크롤 가능하도록 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberBottomSheetScaffoldState
@@ -169,7 +171,8 @@ private fun GroupDetailScreenContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(Gray0)
-                    .padding(top = 10.dp),
+                    .verticalScroll(rememberScrollState())
+                    .padding(top = 10.dp, bottom = 270.dp),
                 status = state.status,
                 event = state.recentEvent,
                 keyword = state.groupInfo?.keyword ?: GroupKeyword.SCHOOL,


### PR DESCRIPTION
## Issue No
- close #204 

## Overview (Required)
- 바텀시트 최소 높이보다 좀 더 크게 패딩 먹이고 스크롤 가능하게끔 수정했습니당

## Screenshot
https://github.com/user-attachments/assets/0c0b9927-3c32-4f23-b2ee-fbaaeceb1496
