### PR TITLE
[#218] 그룹상세 진행중 이벤트 없을때 이벤트 생성 가능하도록 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -109,10 +108,6 @@ fun GroupDetailScreen(
     onClickEventMake: () -> Unit,
     onClickHistoryItem: (HistoryItem) -> Unit,
 ) {
-    val isEnabledNewEvent = remember(state.status) {
-        state.status == GroupStatusType.EVENT_COMPLETED
-    }
-
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
@@ -121,7 +116,7 @@ fun GroupDetailScreen(
             titleText = state.groupInfo?.name.orEmpty(),
             titleAlign = PicTopBarTitleAlign.LEFT,
             backButtonClicked = onClickBackButton,
-            rightIcon1 = if (isEnabledNewEvent) PicTopBarIcon.PLUS else null,
+            rightIcon1 = if (state.isEnabledNewEvent) PicTopBarIcon.PLUS else null,
             rightIcon2 = PicTopBarIcon.GROUP_MEMBER,
             rightIcon1Clicked = onClickEventMake,
             rightIcon2Clicked = onClickGroupMemberButton,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/GroupDetailUiState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/model/GroupDetailUiState.kt
@@ -10,4 +10,7 @@ data class GroupDetailUiState(
     val recentEvent: GroupEvent? = null,
     val history: List<HistoryItem> = emptyList(),
     val isError: Boolean = false,
-)
+) {
+    val isEnabledNewEvent: Boolean
+        get() = status == GroupStatusType.EVENT_COMPLETED || status == GroupStatusType.NO_CURRENT_EVENT
+}


### PR DESCRIPTION
## Issue No
- close #218 

## Overview (Required)
- 그룹상세 진행중 이벤트 없을때 이벤트 생성 가능하도록 수정