### PR TITLE
[#200] 공유하기 버튼 클릭 시 앱 죽는 이슈 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -21,11 +21,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.CardBackImage
@@ -195,7 +197,10 @@ fun PicCroppedPhoto(
     ) {
         AsyncImage(
             modifier = Modifier.matchParentSize(),
-            model = imageUrl,
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(imageUrl)
+                .allowHardware(false)
+                .build(),
             contentScale = ContentScale.Crop,
             contentDescription = stringResource(R.string.group_main_picture),
         )


### PR DESCRIPTION
## Issue No
- close #200 

## Overview (Required)
- 이것저것 열심히 찾아봤는데 요약하자면 picture는 가속화 설정이 안되는데 coil 내부적으로 가속화 설정이 켜져 있어서 안되는가봅니다.. 자세히는 모르겠으니 링크 첨부

## Links
- https://gist.github.com/chiragthummar/35aa1d15882c4d5a105a3f89be821214
- https://stackoverflow.com/questions/78199376/jetpack-compose-java-lang-illegalstateexception-software-rendering-doesnt-su
- 추가로 컴포저블을 캡처하는 최신 방법은 compose-bom 최신 버전에서 ui-graphics 버전이 1.6.8 인데 1.7.0 이상 필요해서 롤백 ([관련 링크](https://developer.android.com/develop/ui/compose/graphics/draw/modifiers#composable-to-bitmap))
