### PR TITLE
[#228] 그룹 생성시 이벤트명 안뜨는 버그 

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -249,6 +249,7 @@ private fun GroupCard(modifier: Modifier, groupInfo: GroupInfo, onClickEventMake
                 groupInfo = groupInfo,
                 contentMaxHeight = contentMaxHeight,
                 backgroundColor = groupInfo.keyword.frontCardBackgroundColor,
+                eventName = groupInfo.recentEvent.title,
                 content = {
                     FrontCardImage(
                         modifier = Modifier
@@ -269,6 +270,7 @@ private fun GroupCard(modifier: Modifier, groupInfo: GroupInfo, onClickEventMake
                 groupInfo = groupInfo,
                 contentMaxHeight = contentMaxHeight,
                 backgroundColor = groupInfo.keyword.behindCardBackGroundColor,
+                eventName = groupInfo.recentEvent.title,
                 content = {
                     BackCardImage(
                         modifier = Modifier


### PR DESCRIPTION
## Issue No
- close #228 

## Overview (Required)
- 이벤트 인자에다가 값을 안넣었더라구요 ㅎ 넣어서 해결했습니다~

## Screenshot
<img src="https://github.com/user-attachments/assets/415524d7-be35-4709-9dcb-df6efac2d760" width = 300 />