### PR TITLE
[#242] 카카오앱 깔려있을 때 카카오로 로그인 되도록 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.auth.KakaoUserSdkUtil
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarHost
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
@@ -51,7 +52,13 @@ class LoginActivity : ComponentActivity() {
                 ) { contentPadding ->
                     Box(modifier = Modifier.padding(contentPadding)) {
                         LoginScreen(
-                            onClickLoginButton = viewModel::login,
+                            onClickLoginButton = {
+                                KakaoUserSdkUtil.loginWithKakao(
+                                    context = this@LoginActivity,
+                                    onSuccess = viewModel::kakaoLoginSuccess,
+                                    onFailure = viewModel::kakaoLoginFailure,
+                                )
+                            },
                         )
                     }
                 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginViewModel.kt
@@ -1,13 +1,11 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.login
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.kakao.sdk.user.model.Profile
 import com.mashup.gabbangzip.sharedalbum.domain.model.LoginParam
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.LoginUseCase
-import com.mashup.gabbangzip.sharedalbum.presentation.auth.KakaoUserSdkUtil
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,42 +15,37 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val loginUseCase: LoginUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-    fun login() {
-        KakaoUserSdkUtil.loginWithKakao(
-            context = context,
-            onSuccess = { idToken, profile ->
-                val nickname = profile.nickname
-                val profileImage = profile.profileImageUrl
-                if (nickname != null && profileImage != null) {
-                    picLogin(
-                        idToken = idToken,
-                        nickname = nickname,
-                        profileImage = profileImage,
-                    )
-                } else {
-                    _uiState.update { state ->
-                        state.copy(
-                            isLoading = false,
-                            errorMessage = "정보 조회 실패",
-                        )
-                    }
-                }
-            },
-            onFailure = {
-                _uiState.update { state ->
-                    state.copy(
-                        isLoading = false,
-                        errorMessage = "카카오 로그인 실패 또는 정보 조회 실패 $it",
-                    )
-                }
-            },
-        )
+    fun kakaoLoginSuccess(idToken: String, profile: Profile) {
+        val nickname = profile.nickname
+        val profileImage = profile.profileImageUrl
+        if (nickname != null && profileImage != null) {
+            picLogin(
+                idToken = idToken,
+                nickname = nickname,
+                profileImage = profileImage,
+            )
+        } else {
+            _uiState.update { state ->
+                state.copy(
+                    isLoading = false,
+                    errorMessage = "정보 조회 실패",
+                )
+            }
+        }
+    }
+
+    fun kakaoLoginFailure(throwable: Throwable?) {
+        _uiState.update { state ->
+            state.copy(
+                isLoading = false,
+                errorMessage = "카카오 로그인 실패 또는 정보 조회 실패 $throwable",
+            )
+        }
     }
 
     private fun picLogin(idToken: String, nickname: String, profileImage: String) {


### PR DESCRIPTION
## Issue No
- close #242 

## Overview (Required)
- 카카오앱 깔려있을 때 카카오로 로그인 되도록 수정
- applicationContext 를 카카오 로그인의 context 로 넣어주면 카카오로그인시 오류가 발생한다. (NEW_TASK 가 불가능한 context 라고 오류가 뜸) 그래서 Activity Context 가 제공되도록 변경하였다.


## Before

https://github.com/user-attachments/assets/a21f347a-6ee8-4bf4-b6a4-95787490371e



## After

https://github.com/user-attachments/assets/04f957d0-7927-448b-8308-ffdd0b1dca49


