### PR TITLE
[#263] 인생네컷 사진 받아올때 4개까지만 받아오도록 방어 코드 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeViewModel.kt
@@ -27,7 +27,8 @@ class GroupHomeViewModel @Inject constructor(
             } else {
                 GroupHomeUiState.GroupList(ImmutableList(groupList.toUiModel()))
             }
-        }.catch {
+        }
+        .catch {
             emit(
                 GroupHomeUiState.Error(
                     when (it) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/CardBackImage.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/CardBackImage.kt
@@ -17,5 +17,9 @@ fun CardBackImageDomainModel.toUiModel(): CardBackImage {
 }
 
 fun List<CardBackImageDomainModel>.toUiModel(): List<CardBackImage> {
-    return map { it.toUiModel() }
+    return if (size >= 4) {
+        take(4).toUiModel()
+    } else {
+        emptyList()
+    }
 }


### PR DESCRIPTION
## Issue No
- close #263 

## Overview (Required)
- 4개만 받아오도록 코드 수정했습니다~~
- 4개 이하면 뭔가 부분적으로 보여주는거 보다 empty로 반환해서 그냥 카드 플립안되게 하는게 나을거 같고 안보여주는게 나을거 같다는 생각에 4개이면 empty로 반환하게 했습니다.. 다른 방법이 낫다고 하면 코멘트 주세용~