### PR TITLE
[#264][#268] 로딩 인디케이터 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicLoadingIndicator.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicLoadingIndicator.kt
@@ -1,0 +1,72 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.common
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Conifer
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Coral
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Dandelion
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Lavender
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.MagentaPink
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Malibu
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.MayaBlue
+
+private val colorList = listOf(
+    Conifer,
+    MayaBlue,
+    MagentaPink,
+    Lavender,
+    Coral,
+    Dandelion,
+    Malibu,
+)
+
+@Composable
+fun PicLoadingIndicator(modifier: Modifier, isVisible: Boolean) {
+    if (isVisible) {
+        val infiniteTransition = rememberInfiniteTransition(label = "InfiniteTransition")
+        val transition = infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 10_000, easing = LinearEasing),
+            ),
+            label = "InfiniteTransition",
+        )
+        val currentColorIndex = ((transition.value * colorList.size).toInt() % colorList.size)
+        val loadingColor by animateColorAsState(
+            targetValue = colorList[currentColorIndex],
+            animationSpec = tween(durationMillis = 1000, easing = LinearEasing),
+            label = "LoadingAnimation",
+        )
+
+        Box(
+            modifier = modifier,
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.align(Alignment.Center),
+                color = loadingColor,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PicLoadingScreenPreview() {
+    PicLoadingIndicator(
+        modifier = Modifier.fillMaxSize(),
+        isVisible = true,
+    )
+}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
@@ -73,6 +73,7 @@ class EventCreationActivity : ComponentActivity() {
                         eventCreationState = state,
                         clearEventCreationState = eventCreationViewModel::clearEventCreationState,
                         onCompleteButtonClicked = { description ->
+                            eventCreationViewModel.updateLoadingState(isLoading = true)
                             state.pictures
                                 .mapNotNull { uri ->
                                     FileUtil.getFileFromUri(this@EventCreationActivity, uri)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationState.kt
@@ -8,6 +8,7 @@ data class EventCreationState(
     val date: String = LocalDateUtil.getNowDate(),
     val pictures: ImmutableList<Uri?> = ImmutableList(emptyList()),
     val eventCreationSuccess: Long? = null,
+    val isLoading: Boolean = false,
 )
 
 sealed interface EventCreationEvent {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationViewModel.kt
@@ -78,11 +78,17 @@ class EventCreationViewModel @Inject constructor(
             ).onSuccess {
                 Log.d(TAG, "이벤트 생성 성공")
                 _uiState.update { it.copy(eventCreationSuccess = groupId) }
+                updateLoadingState(isLoading = false)
             }.onFailure {
                 Log.d(TAG, "이벤트 생성 실패")
                 showSnackBar()
+                updateLoadingState(isLoading = false)
             }
         }
+    }
+
+    fun updateLoadingState(isLoading: Boolean) {
+        _uiState.update { it.copy(isLoading = isLoading) }
     }
 
     private fun showSnackBar() {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/detail/EventCreationDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/detail/EventCreationDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -41,6 +42,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicDatePickerField
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicDialog
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicGallery
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicLoadingIndicator
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTextField
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.eventcreation.EventCreationActivity.Companion.PICTURES_MAX_COUNT
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.eventcreation.EventCreationState
@@ -161,6 +163,7 @@ fun EventCreationDetailScreen(
             },
         )
     }
+    PicLoadingIndicator(modifier = Modifier.fillMaxSize(), isVisible = state.isLoading)
 }
 
 @Composable

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationUiState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationUiState.kt
@@ -9,6 +9,7 @@ data class GroupCreationUiState(
     val keyword: GroupKeyword = GroupKeyword.SCHOOL,
     val thumbnail: Uri? = null,
     val groupCreationResult: GroupCreationResult? = null,
+    val isLoading: Boolean = false,
 ) {
     val isGroupCreated get() = groupCreationResult != null
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
@@ -54,6 +55,7 @@ class GroupCreationViewModel @Inject constructor(
     }
 
     fun createGroup(name: String, keyword: String, file: File) {
+        updateLoadingState(isLoading = true)
         viewModelScope.launch {
             createGroupUseCase(
                 name = name,
@@ -68,10 +70,17 @@ class GroupCreationViewModel @Inject constructor(
                             imageUrl = it.imageUrl,
                             invitationCode = it.invitationCode,
                         ),
+                        isLoading = false,
                     ),
                 )
             }.onFailure {
-                _effect.emit(Event.ShowSnackBarMessageRes(PicSnackbarType.WARNING, message = R.string.image_upload_failed))
+                _effect.emit(
+                    Event.ShowSnackBarMessageRes(
+                        PicSnackbarType.WARNING,
+                        message = R.string.image_upload_failed,
+                    ),
+                )
+                updateLoadingState(isLoading = false)
             }
         }
     }
@@ -88,9 +97,16 @@ class GroupCreationViewModel @Inject constructor(
         }
     }
 
+    private fun updateLoadingState(isLoading: Boolean) {
+        _uiState.update {
+            it.copy(isLoading = isLoading)
+        }
+    }
+
     sealed interface Event {
         data class ShowSnackBarMessage(val type: PicSnackbarType, val message: String) : Event
-        data class ShowSnackBarMessageRes(val type: PicSnackbarType, @StringRes val message: Int) : Event
+        data class ShowSnackBarMessageRes(val type: PicSnackbarType, @StringRes val message: Int) :
+            Event
     }
 
     companion object {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
@@ -6,6 +6,7 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -36,6 +37,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicBackButtonTopBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicButton
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicLoadingIndicator
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicProgressBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.GroupCreationUiState
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common.GroupCreationScaffold
@@ -135,6 +137,12 @@ private fun GroupCreationThumbnailScreen(
                     .height(60.dp),
             )
         },
+    )
+    PicLoadingIndicator(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Gray0),
+        isVisible = state.isLoading,
     )
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
@@ -16,22 +17,26 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicLoadingIndicator
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarHost
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.showPicSnackbar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.GroupCreationActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.login.LoginActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.navigation.navigateGroupDetail
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.model.MainEvent
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.navigation.MainNavHost
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.navigation.MainRoute
-import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.MainEvent
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.FileUtil
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.PicPhotoPicker
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.shareBitmap
@@ -55,6 +60,7 @@ class MainActivity : ComponentActivity() {
         initPhotoPicker()
 
         setContent {
+            val state by viewModel.mainState.collectAsStateWithLifecycle()
             val snackbarHostState = remember { SnackbarHostState() }
             val coroutineScope = rememberCoroutineScope()
             val navController = rememberNavController()
@@ -105,6 +111,13 @@ class MainActivity : ComponentActivity() {
                         navController.navigateGroupDetail(groupId)
                     }
                 }
+
+                PicLoadingIndicator(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(color = Gray0),
+                    isVisible = state.isLoading,
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -53,6 +53,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray20
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.FlippableBox
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicLoadingIndicator
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTag
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTopBar
@@ -108,6 +109,10 @@ fun GroupHomeScreen(
         is GroupHomeUiState.Error -> {
             val message = (state as GroupHomeUiState.Error).errorMessage
             onShowSnackbar(PicSnackbarType.WARNING, stringResource(id = message))
+        }
+
+        is GroupHomeUiState.Loading -> {
+            PicLoadingIndicator(modifier = Modifier.fillMaxSize(), isVisible = true)
         }
 
         else -> {}

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeViewModel.kt
@@ -41,6 +41,6 @@ class GroupHomeViewModel @Inject constructor(
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(),
-            initialValue = GroupHomeUiState.NotInitialized,
+            initialValue = GroupHomeUiState.Loading,
         )
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/CardBackImage.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/CardBackImage.kt
@@ -18,7 +18,7 @@ fun CardBackImageDomainModel.toUiModel(): CardBackImage {
 
 fun List<CardBackImageDomainModel>.toUiModel(): List<CardBackImage> {
     return if (size >= 4) {
-        take(4).toUiModel()
+        take(4).map { it.toUiModel() }
     } else {
         emptyList()
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/model/MainEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/model/MainEvent.kt
@@ -1,4 +1,4 @@
-package com.mashup.gabbangzip.sharedalbum.presentation.ui.model
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.model
 
 sealed interface MainEvent {
     data object SuccessNotification : MainEvent

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/model/MainUiState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/model/MainUiState.kt
@@ -1,0 +1,5 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.model
+
+data class MainUiState(
+    val isLoading: Boolean = false,
+)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/PhotoVoteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/PhotoVoteScreen.kt
@@ -45,6 +45,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicDialog
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicLoadingIndicator
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.UserInfo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.vote.contract.VoteConstant
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.vote.model.PhotoVoteState
@@ -132,6 +133,12 @@ fun PhotoVoteScreen(
             VoteGuideContainer(modifier = Modifier.fillMaxSize())
         }
     }
+    PicLoadingIndicator(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Gray0),
+        isVisible = state.isLoading,
+    )
 }
 
 @Composable

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/VoteViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/VoteViewModel.kt
@@ -37,6 +37,7 @@ class VoteViewModel @Inject constructor(
     private val likedPhotoList = mutableListOf<VotePhoto>()
 
     init {
+        updateLoadingState(isLoading = true)
         checkFirstVisit()
     }
 
@@ -126,9 +127,9 @@ class VoteViewModel @Inject constructor(
                     state.copy(
                         voteResult = voteResultDomain.toUiModel(),
                         isVoteUploadFinish = true,
+                        isLoading = false,
                     )
                 }
-                updateLoadingState(isLoading = false)
             }.onFailure {
                 updateLoadingState(isLoading = false)
                 _voteUiState.update { state ->

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/VoteViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/VoteViewModel.kt
@@ -54,21 +54,25 @@ class VoteViewModel @Inject constructor(
     fun fetchVotePhotoList(eventIdKey: String) {
         savedStateHandle.get<Long>(eventIdKey)?.let { eventId ->
             viewModelScope.launch {
-                getVotePhotoListUseCase(eventId).onSuccess { votePhotoList ->
-                    _voteUiState.update { state ->
-                        state.copy(
-                            photoList = ImmutableList(votePhotoList.toUiModel()),
-                            voteResult = state.voteResult.copy(
-                                eventId = eventId,
-                            ),
-                            voteClickInfo = state.voteClickInfo.copy(
-                                index = votePhotoList.size,
-                            ),
-                        )
+                getVotePhotoListUseCase(eventId)
+                    .onSuccess { votePhotoList ->
+                        _voteUiState.update { state ->
+                            state.copy(
+                                photoList = ImmutableList(votePhotoList.toUiModel()),
+                                voteResult = state.voteResult.copy(
+                                    eventId = eventId,
+                                ),
+                                voteClickInfo = state.voteClickInfo.copy(
+                                    index = votePhotoList.size,
+                                ),
+                                isLoading = false,
+                            )
+                        }
                     }
-                }.onFailure {
-                    updateErrorState()
-                }
+                    .onFailure {
+                        updateLoadingState(isLoading = false)
+                        updateErrorState()
+                    }
             }
         } ?: updateErrorState()
     }
@@ -110,6 +114,7 @@ class VoteViewModel @Inject constructor(
     }
 
     fun finishVote() {
+        updateLoadingState(isLoading = true)
         viewModelScope.launch {
             requestVoteResultUseCase(
                 VoteResultParam(
@@ -123,7 +128,9 @@ class VoteViewModel @Inject constructor(
                         isVoteUploadFinish = true,
                     )
                 }
+                updateLoadingState(isLoading = false)
             }.onFailure {
+                updateLoadingState(isLoading = false)
                 _voteUiState.update { state ->
                     state.copy(
                         isVoteUploadFinish = false,
@@ -138,6 +145,12 @@ class VoteViewModel @Inject constructor(
             state.copy(
                 isError = true,
             )
+        }
+    }
+
+    private fun updateLoadingState(isLoading: Boolean) {
+        _voteUiState.update {
+            it.copy(isLoading = isLoading)
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/VoteViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/VoteViewModel.kt
@@ -37,7 +37,6 @@ class VoteViewModel @Inject constructor(
     private val likedPhotoList = mutableListOf<VotePhoto>()
 
     init {
-        updateLoadingState(isLoading = true)
         checkFirstVisit()
     }
 
@@ -53,6 +52,7 @@ class VoteViewModel @Inject constructor(
     }
 
     fun fetchVotePhotoList(eventIdKey: String) {
+        updateLoadingState(isLoading = true)
         savedStateHandle.get<Long>(eventIdKey)?.let { eventId ->
             viewModelScope.launch {
                 getVotePhotoListUseCase(eventId)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/model/PhotoVoteState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/model/PhotoVoteState.kt
@@ -9,7 +9,7 @@ data class PhotoVoteState(
     val voteResult: VoteResult = VoteResult(),
     val voteClickInfo: VoteClickInfo = VoteClickInfo(),
     val isVoteCancel: Boolean = false,
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
     val isVoteUploadFinish: Boolean? = null,
     val isError: Boolean = false,
     val isFirstVisit: Boolean = false,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/model/PhotoVoteState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/model/PhotoVoteState.kt
@@ -9,7 +9,7 @@ data class PhotoVoteState(
     val voteResult: VoteResult = VoteResult(),
     val voteClickInfo: VoteClickInfo = VoteClickInfo(),
     val isVoteCancel: Boolean = false,
-    val isLoading: Boolean = true,
+    val isLoading: Boolean = false,
     val isVoteUploadFinish: Boolean? = null,
     val isError: Boolean = false,
     val isFirstVisit: Boolean = false,


### PR DESCRIPTION
## Issue No
- close #264 
- close #268 

## Overview (Required)
- 로딩화면 구현 완료했습니다~~ 뭔가 그냥 단색 프로그레스바로 로딩도는게 안이뻐서 저희 키워드 색깔로 구현했습니다. 별로면 말해주기..ㅎ
- 픽 고르고 사진 선택해서 업로드, 그룹 홈으로 진입, 그룹만들기, 이벤트 만들기, 투표 시작전, 투표 완료 할때 로딩 추가 했습니다. 다른 것도 있다면 말해 주십셔.
- 진짜 대박 사건인게 인생네컷 방어하기 코드도 map을 안넣고 toUiModel하는 바람의 재귀가 돌아서 무한루프가 돌더라구요..ㅎ 수정했습니다 같이...

## Screenshot
**[로딩 인디케이터]**

https://github.com/user-attachments/assets/d16dc871-a4a1-4c89-a870-3b854baeae1e


**[그룹 홈 진입 로딩 ]**

https://github.com/user-attachments/assets/aac1900d-d894-4c17-8a74-b0261dd5a848

**[그룹 만들기 로딩]**

https://github.com/user-attachments/assets/73ad907f-0956-48bc-9f03-0e74552a7be3

**[픽고르기 로딩]**

https://github.com/user-attachments/assets/671ae8c7-e461-41f5-ba6a-3f7782b37ed3

- 위 동영상과 같은 느낌입니다.. ㅎ 빠진게 있는데 못찍었습니다,,,,ㅎ


