### PR TITLE
[#247] 내픽올리기 / 이벤트만들기 등 속도 개선

### DIFF
--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/UploadImageListUseCase.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/UploadImageListUseCase.kt
@@ -1,0 +1,26 @@
+package com.mashup.gabbangzip.sharedalbum.domain.usecase
+
+import dagger.Reusable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import java.io.File
+import javax.inject.Inject
+
+@Reusable
+class UploadImageListUseCase @Inject constructor(
+    private val uploadImageUseCase: UploadImageUseCase,
+) {
+    suspend operator fun invoke(fileList: List<File>): Result<List<String>> {
+        return runCatching {
+            coroutineScope {
+                fileList.map { file ->
+                    async(Dispatchers.IO) {
+                        uploadImageUseCase(file).getOrThrow()
+                    }
+                }.awaitAll()
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/UploadImageListUseCase.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/UploadImageListUseCase.kt
@@ -1,7 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.domain.usecase
 
 import dagger.Reusable
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -16,7 +15,7 @@ class UploadImageListUseCase @Inject constructor(
         return runCatching {
             coroutineScope {
                 fileList.map { file ->
-                    async(Dispatchers.IO) {
+                    async {
                         uploadImageUseCase(file).getOrThrow()
                     }
                 }.awaitAll()

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/UploadMyPicUseCase.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/usecase/UploadMyPicUseCase.kt
@@ -4,16 +4,12 @@ import com.mashup.gabbangzip.sharedalbum.domain.model.event.UploadMyPicDomainMod
 import com.mashup.gabbangzip.sharedalbum.domain.model.event.UploadMyPicParam
 import com.mashup.gabbangzip.sharedalbum.domain.repository.EventRepository
 import dagger.Reusable
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import java.io.File
 import javax.inject.Inject
 
 @Reusable
 class UploadMyPicUseCase @Inject constructor(
-    private val uploadImageUseCase: UploadImageUseCase,
+    private val uploadImageListUseCase: UploadImageListUseCase,
     private val eventRepository: EventRepository,
 ) {
     suspend operator fun invoke(
@@ -21,17 +17,11 @@ class UploadMyPicUseCase @Inject constructor(
         fileList: List<File>,
     ): Result<UploadMyPicDomainModel> {
         return runCatching {
-            coroutineScope {
-                val pictureList = fileList.map { file ->
-                    async(Dispatchers.IO) {
-                        uploadImageUseCase(file).getOrThrow()
-                    }
-                }
+            val pictureList = uploadImageListUseCase(fileList).getOrThrow()
 
-                eventRepository.uploadMyPic(
-                    UploadMyPicParam(eventId, pictureList.awaitAll()),
-                )
-            }
+            eventRepository.uploadMyPic(
+                UploadMyPicParam(eventId, pictureList),
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
@@ -3,6 +3,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.eventcreation
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -15,11 +16,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
@@ -30,6 +33,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.eventcreation.navigatio
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.eventcreation.navigation.EventCreationRoute
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.MainActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.FileUtil
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.PicPhotoPicker
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -60,7 +64,6 @@ class EventCreationActivity : ComponentActivity() {
         setContent {
             val state by eventCreationViewModel.uiState.collectAsStateWithLifecycle()
             val snackbarHostState = remember { SnackbarHostState() }
-            val coroutineScope = rememberCoroutineScope()
 
             SharedAlbumTheme {
                 Scaffold(
@@ -79,26 +82,7 @@ class EventCreationActivity : ComponentActivity() {
                         eventCreationState = state,
                         clearEventCreationState = eventCreationViewModel::clearEventCreationState,
                         onCompleteButtonClicked = { description ->
-                            eventCreationViewModel.updateLoadingState(isLoading = true)
-                            coroutineScope.launch(Dispatchers.IO) {
-                                state.pictures
-                                    .mapNotNull { uri ->
-                                        uri?.let {
-                                            async {
-                                                FileUtil.getJpgImage(
-                                                    this@EventCreationActivity,
-                                                    uri,
-                                                )
-                                            }
-                                        }
-                                    }
-                                    .also {
-                                        eventCreationViewModel.checkEventCreation(
-                                            description,
-                                            it.awaitAll(),
-                                        )
-                                    }
-                            }
+                            checkCreation(state.pictures, description)
                         },
                         onGalleryButtonClicked = photoPicker::open,
                         onPictureDeleteButtonClicked = eventCreationViewModel::deletePicture,
@@ -115,27 +99,51 @@ class EventCreationActivity : ComponentActivity() {
                     )
                     finish()
                 }
+                ObserveEvent(snackbarHostState)
+            }
+        }
+    }
 
-                LaunchedEffect(true) {
-                    eventCreationViewModel.eventFlow.collect {
-                        when (it) {
-                            is EventCreationEvent.Error -> {
-                                snackbarHostState.showPicSnackbar(
-                                    type = PicSnackbarType.WARNING,
-                                    message = getString(R.string.image_retrieve_failed),
-                                )
-                            }
+    @Composable
+    private fun ObserveEvent(snackbarHostState: SnackbarHostState) {
+        LaunchedEffect(null) {
+            eventCreationViewModel.eventFlow.collect {
+                when (it) {
+                    is EventCreationEvent.Error -> {
+                        snackbarHostState.showPicSnackbar(
+                            type = PicSnackbarType.WARNING,
+                            message = getString(R.string.image_retrieve_failed),
+                        )
+                    }
 
-                            is EventCreationEvent.OverflowImageError -> {
-                                snackbarHostState.showPicSnackbar(
-                                    type = PicSnackbarType.WARNING,
-                                    message = getString(R.string.image_overflow_failed)
-                                        .format(PICTURES_MAX_COUNT),
-                                )
-                            }
-                        }
+                    is EventCreationEvent.OverflowImageError -> {
+                        snackbarHostState.showPicSnackbar(
+                            type = PicSnackbarType.WARNING,
+                            message = getString(R.string.image_overflow_failed)
+                                .format(PICTURES_MAX_COUNT),
+                        )
                     }
                 }
+            }
+        }
+    }
+
+    private fun checkCreation(pictures: ImmutableList<Uri?>, description: String) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            pictures.mapNotNull { uri ->
+                uri?.let {
+                    async {
+                        FileUtil.getJpgImage(
+                            this@EventCreationActivity,
+                            uri,
+                        )
+                    }
+                }
+            }.also {
+                eventCreationViewModel.checkEventCreation(
+                    description,
+                    it.awaitAll(),
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/MainActivity.kt
@@ -3,6 +3,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main
 import android.app.Activity
 import android.content.Intent
 import android.graphics.Color.TRANSPARENT
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -133,15 +134,19 @@ class MainActivity : ComponentActivity() {
             activity = this,
             max = PICTURES_MAX_COUNT,
         ) { uriList ->
-            lifecycleScope.launch {
-                uriList.mapNotNull { uri ->
-                    uri?.let {
-                        async(Dispatchers.IO) {
-                            FileUtil.getJpgImage(this@MainActivity, it)
-                        }
+            uploadPic(uriList)
+        }
+    }
+
+    private fun uploadPic(uriList: List<Uri?>) {
+        lifecycleScope.launch {
+            uriList.mapNotNull { uri ->
+                uri?.let {
+                    async(Dispatchers.IO) {
+                        FileUtil.getJpgImage(this@MainActivity, it)
                     }
-                }.also { viewModel.uploadMyPic(it.awaitAll()) }
-            }
+                }
+            }.also { viewModel.uploadMyPic(it.awaitAll()) }
         }
     }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/FileUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/FileUtil.kt
@@ -1,10 +1,15 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.utils
 
 import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import android.media.ExifInterface
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
 import android.provider.OpenableColumns
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 
@@ -15,6 +20,58 @@ object FileUtil {
             getFileFromUriSDK33AndAbove(context, uri)
         } else {
             getFileFromUriBelowSDK33(context, uri)
+        }
+    }
+
+    fun getJpgImage(context: Context, uri: Uri): File {
+        val inputStream = context.contentResolver.openInputStream(uri)
+        val bitmap = BitmapFactory.decodeStream(inputStream).run {
+            adjustBitmapOrientation(context, uri, this)
+        }
+
+        val outputStream = ByteArrayOutputStream().apply {
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 50, this)
+        }
+
+        val jpgData = outputStream.toByteArray()
+
+        return File.createTempFile("compress_image", ".jpeg", context.cacheDir)
+            .apply {
+                FileOutputStream(this).use { fileOutputStream ->
+                    fileOutputStream.write(jpgData)
+                }
+            }
+            .also {
+                outputStream.close()
+                inputStream?.close()
+            }
+    }
+
+    private fun adjustBitmapOrientation(context: Context, uri: Uri, bitmap: Bitmap): Bitmap {
+        val inputStream = context.contentResolver.openInputStream(uri) ?: return bitmap
+        val exifAttr = ExifInterface(inputStream).getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_NORMAL,
+        )
+        val rotation = when (exifAttr) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+            ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+            ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+            else -> 0f
+        }
+
+        inputStream.close()
+
+        return if (rotation != 0f) {
+            val matrix = Matrix().apply { postRotate(rotation) }
+            Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+                .also {
+                    if (it != bitmap) {
+                        bitmap.recycle()
+                    }
+                }
+        } else {
+            bitmap
         }
     }
 


### PR DESCRIPTION
## Issue No
- close #247

## Overview (Required)
- jpeg 압축 및 변환, async 이용해서 업로드 속도 단축했습니당
- 코루틴을 맞게 사용되어있는지는 사실 아직 아리까리 하네용..? 보통 내픽올리기나 이벤트 만들때 사진 가져올 시, 메인 스레드에서 실행 되지만 파일 압축,변환 작업은 Dispathcer.IO로 백그라운드 작업하는 거를 의도했는데 아니라면 코멘트 부탁드립니당..
- 성능 비교는 아래 링크 참조해 주세용~~
## Links
- https://www.notion.so/7bf969c4c1f741679ad5bac848dc4465?pvs=4
- https://s2choco.tistory.com/18