### PR TITLE
[#201] 홈 포토카드 뒷면 이미지 짤림 방지

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomePhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomePhotoCard.kt
@@ -30,16 +30,13 @@ import com.mashup.gabbangzip.sharedalbum.presentation.utils.StableImage
 fun GroupHomePhotoCard(
     modifier: Modifier,
     groupInfo: GroupInfo,
-    contentMaxHeight: Dp,
     backgroundColor: Color,
     content: @Composable BoxScope.() -> Unit,
     eventName: String = "",
     onClickEventMake: (Long) -> Unit,
 ) {
     GroupPhotoCardContainer(
-        modifier = modifier
-            .heightIn(max = contentMaxHeight)
-            .wrapContentSize(),
+        modifier = modifier.wrapContentSize(),
         keywordType = groupInfo.keyword,
         backgroundColor = backgroundColor,
     ) {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomePhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomePhotoCard.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
@@ -15,7 +14,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
@@ -254,15 +255,12 @@ private fun GroupContainer(
 
 @Composable
 private fun GroupCard(modifier: Modifier, groupInfo: GroupInfo, onClickEventMake: (Long) -> Unit) {
-    val contentMaxHeight = LocalConfiguration.current.screenHeightDp.dp.div(2)
-
     FlippableBox(
         modifier = modifier,
         frontScreen = {
             GroupHomePhotoCard(
                 modifier = Modifier,
                 groupInfo = groupInfo,
-                contentMaxHeight = contentMaxHeight,
                 backgroundColor = groupInfo.keyword.frontCardBackgroundColor,
                 eventName = groupInfo.recentEvent.title,
                 content = {
@@ -283,7 +281,6 @@ private fun GroupCard(modifier: Modifier, groupInfo: GroupInfo, onClickEventMake
             GroupHomePhotoCard(
                 modifier = Modifier,
                 groupInfo = groupInfo,
-                contentMaxHeight = contentMaxHeight,
                 backgroundColor = groupInfo.keyword.behindCardBackGroundColor,
                 eventName = groupInfo.recentEvent.title,
                 content = {
@@ -369,7 +366,7 @@ private fun FrontCardImage(
             contentDescription = stringResource(R.string.group_main_picture),
         )
         StableImage(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.aspectRatio(1f),
             drawableResId = frameResId,
             colorFilter = ColorFilter.tint(backgroundColor),
             contentScale = ContentScale.FillBounds,
@@ -384,8 +381,9 @@ private fun BackCardImage(
     cardBackImageList: List<CardBackImage>,
     backgroundColor: Color,
 ) {
+    val contentMaxHeight = LocalConfiguration.current.screenHeightDp.dp
     LazyVerticalGrid(
-        modifier = modifier.wrapContentSize(),
+        modifier = modifier.wrapContentSize().heightIn(max = contentMaxHeight),
         verticalArrangement = Arrangement.spacedBy(7.46.dp),
         horizontalArrangement = Arrangement.spacedBy(7.46.dp),
         columns = GridCells.Fixed(2),


### PR DESCRIPTION
## Issue No
- close #201 

## Overview (Required)
- 홈 포토카드 뒷면 이미지 짤림 방지

### 해결과정
- contentMaxHeight 가 기기의 절반사이즈이다. 그래서 기기에 따라 뒷면 이미지가 한번에 표현되지 못할 수 있다.
=> contentMaxHeight 제거, LazyVerticalGrid 가 적용된 BackImage 에만 기기의 높이만큼 max height 값을 주었음 (어차피 이 값을 넘을 수 없음) 이렇게하면 FrontImage 와 BackImage 를 모두 가변높이로 잡아줄 수 있음
- BackImage 는 1:1 비율이지만, FrontImage 는 1:1 비율이 아니어서, 두 화면의 높이가 상이한 문제점 발생
=> FrontImage 에 aspectRatio 를 통해 1:1 비율로 제공하도록 수정

## Screenshot

**Before**

https://github.com/user-attachments/assets/573758dc-9198-419c-9770-d9b4a9afb776





**After**

https://github.com/user-attachments/assets/225ceb22-a853-4cda-aab2-a969d726c4ab

