### PR TITLE
[#246] 이미지 하나씩 업로드 할 수 있도록 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
@@ -107,6 +107,14 @@ class EventCreationActivity : ComponentActivity() {
                                     message = getString(R.string.image_retrieve_failed),
                                 )
                             }
+
+                            EventCreationEvent.OverflowImageError -> {
+                                snackbarHostState.showPicSnackbar(
+                                    type = PicSnackbarType.WARNING,
+                                    message = getString(R.string.image_overflow_failed)
+                                        .format(PICTURES_MAX_COUNT),
+                                )
+                            }
                         }
                     }
                 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationActivity.kt
@@ -108,7 +108,7 @@ class EventCreationActivity : ComponentActivity() {
                                 )
                             }
 
-                            EventCreationEvent.OverflowImageError -> {
+                            is EventCreationEvent.OverflowImageError -> {
                                 snackbarHostState.showPicSnackbar(
                                     type = PicSnackbarType.WARNING,
                                     message = getString(R.string.image_overflow_failed)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationState.kt
@@ -13,4 +13,5 @@ data class EventCreationState(
 
 sealed interface EventCreationEvent {
     data object Error : EventCreationEvent
+    data object OverflowImageError : EventCreationEvent
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/EventCreationViewModel.kt
@@ -36,11 +36,12 @@ class EventCreationViewModel @Inject constructor(
     fun updatePictures(uriList: List<Uri?>) {
         viewModelScope.launch {
             val currentList = uiState.value.pictures
-            val addedList = if (currentList.size + uriList.size > EventCreationActivity.PICTURES_MAX_COUNT) {
+            val uriListNotNull = uriList.filterNotNull()
+            val addedList = if (currentList.size + uriListNotNull.size > EventCreationActivity.PICTURES_MAX_COUNT) {
                 _eventFlow.emit(EventCreationEvent.OverflowImageError)
-                uriList.filterNotNull().take(EventCreationActivity.PICTURES_MAX_COUNT - currentList.size)
+                uriListNotNull.take(EventCreationActivity.PICTURES_MAX_COUNT - currentList.size)
             } else {
-                uriList.filterNotNull()
+                uriListNotNull
             }
             _uiState.update { it.copy(pictures = ImmutableList(currentList + addedList)) }
         }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -114,7 +114,7 @@
 
     <string name="image_upload_failed">이미지 업로드 실패</string>
     <string name="image_retrieve_failed">이미지 파일 조회 실패</string>
-    <string name="image_overflow_failed">이미지 개수가 %d 장을 초과하였습니다</string>
+    <string name="image_overflow_failed">이미지 개수가 %d장을 초과하였습니다</string>
 
     <string name="enter_group_by_code_title">그룹 들어가기</string>
     <string name="enter_group_by_code_input_title">초대코드를 입력해주세요</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
 
     <string name="image_upload_failed">이미지 업로드 실패</string>
     <string name="image_retrieve_failed">이미지 파일 조회 실패</string>
+    <string name="image_overflow_failed">이미지 개수가 %d 장을 초과하였습니다</string>
 
     <string name="enter_group_by_code_title">그룹 들어가기</string>
     <string name="enter_group_by_code_input_title">초대코드를 입력해주세요</string>


### PR DESCRIPTION
## Issue No
- close #246 

## Overview (Required)
- 이벤트 생성하기, 4개 이미지 업로드 시 하나씩 업로드도 가능하도록 개선
- 4개 이상 선택되면 경고메시지가 뜨면서 나머지 이미지들은 등록되지 않게 구현완료

## Screenshot

https://github.com/user-attachments/assets/c9ed5626-c2d3-4825-a700-216c4b97d248

