### PR TITLE
[#289] 히스토리 상세화면 사진공유 기능 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTopBar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTopBar.kt
@@ -76,10 +76,7 @@ fun PicBackButtonTopBar(
     rightIcon2Clicked: () -> Unit = {},
 ) {
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-            .padding(vertical = 14.dp, horizontal = 16.dp),
+        modifier = modifier,
         contentAlignment = Alignment.Center,
     ) {
         Row(
@@ -178,15 +175,20 @@ private fun PicTopBarPreview() {
             )
             PicBackButtonTopBar(
                 modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
                     .background(Gray0.copy(alpha = 0.2f))
-                    .padding(top = 56.dp),
+                    .padding(top = 70.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                 titleText = "그룹 만들기",
                 backButtonClicked = {},
             )
             PicBackButtonTopBar(
                 modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
                     .background(Gray0.copy(alpha = 0.2f))
-                    .padding(top = 56.dp),
+                    .padding(top = 70.dp, bottom = 14.dp, start = 16.dp, end = 16.dp)
+                    .padding(vertical = 14.dp, horizontal = 16.dp),
                 titleText = "뛰뛰빵빵 가빵집",
                 titleAlign = PicTopBarTitleAlign.LEFT,
                 backButtonClicked = {},

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTopBar.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTopBar.kt
@@ -187,8 +187,7 @@ private fun PicTopBarPreview() {
                     .fillMaxWidth()
                     .wrapContentHeight()
                     .background(Gray0.copy(alpha = 0.2f))
-                    .padding(top = 70.dp, bottom = 14.dp, start = 16.dp, end = 16.dp)
-                    .padding(vertical = 14.dp, horizontal = 16.dp),
+                    .padding(top = 70.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                 titleText = "뛰뛰빵빵 가빵집",
                 titleAlign = PicTopBarTitleAlign.LEFT,
                 backButtonClicked = {},

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/detail/EventCreationDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/detail/EventCreationDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -88,8 +89,10 @@ fun EventCreationDetailScreen(
     ) {
         PicBackButtonTopBar(
             modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
                 .background(Gray0Alpha80)
-                .padding(top = 16.dp),
+                .padding(top = 30.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
             titleText = stringResource(id = R.string.event_creation),
             backButtonClicked = {
                 focusManager.clearFocus()

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/keyword/GroupCreationKeywordScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -58,8 +59,10 @@ private fun GroupCreationKeywordScreen(
         topBar = {
             PicBackButtonTopBar(
                 modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
                     .background(Gray0Alpha80)
-                    .padding(top = 16.dp),
+                    .padding(top = 30.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                 titleText = stringResource(id = R.string.group_creation_button_name),
                 backButtonClicked = onBackButtonClicked,
             )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/name/GroupCreationNameScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -66,8 +67,10 @@ private fun GroupCreationNameScreen(
         topBar = {
             PicBackButtonTopBar(
                 modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
                     .background(Gray0Alpha80)
-                    .padding(top = 16.dp),
+                    .padding(top = 30.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                 titleText = stringResource(id = R.string.group_creation_button_name),
                 backButtonClicked = {
                     focusManager.clearFocus()

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
@@ -96,8 +96,10 @@ private fun GroupCreationThumbnailScreen(
         topBar = {
             PicBackButtonTopBar(
                 modifier = Modifier
+                    .fillMaxWidth()
+                    .wrapContentHeight()
                     .background(Gray0Alpha80)
-                    .padding(top = 16.dp),
+                    .padding(top = 30.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
                 titleText = stringResource(id = R.string.group_creation_button_name),
                 backButtonClicked = onBackButtonClicked,
             )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -36,6 +37,10 @@ fun InvitationCodeScreen(
         modifier = Modifier.fillMaxSize(),
     ) {
         PicBackButtonTopBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(vertical = 14.dp, horizontal = 16.dp),
             titleText = stringResource(id = R.string.enter_group_by_code_title),
             backButtonClicked = onBackButtonClicked,
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetScaffold
@@ -138,7 +139,10 @@ fun GroupDetailScreen(
             modifier = Modifier.fillMaxSize(),
             topBar = {
                 PicBackButtonTopBar(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentHeight()
+                        .padding(vertical = 14.dp, horizontal = 16.dp),
                     titleText = state.groupInfo?.name.orEmpty(),
                     titleAlign = PicTopBarTitleAlign.LEFT,
                     backButtonClicked = onClickBackButton,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailActivity.kt
@@ -8,9 +8,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.shareBitmap
@@ -30,7 +33,10 @@ class HistoryDetailActivity : ComponentActivity() {
                 state?.let { state ->
                     Scaffold { innerPadding ->
                         HistoryDetailScreen(
-                            modifier = Modifier.padding(innerPadding),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color(0xFF555555)) // Todo : 추후 Design System 색상값 받기
+                                .padding(innerPadding),
                             groupName = state.groupName,
                             keyword = GroupKeyword.getKeyword(state.keyword),
                             item = state.history,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailActivity.kt
@@ -8,8 +8,12 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.shareBitmap
 
 class HistoryDetailActivity : ComponentActivity() {
     private val state by lazy { intent.getSerializableExtra(KEY_HISTORY) as HistoryDetailState? }
@@ -24,12 +28,16 @@ class HistoryDetailActivity : ComponentActivity() {
         setContent {
             SharedAlbumTheme {
                 state?.let { state ->
-                    HistoryDetailScreen(
-                        groupName = state.groupName,
-                        keyword = GroupKeyword.getKeyword(state.keyword),
-                        item = state.history,
-                        onClickBackButton = { finish() },
-                    )
+                    Scaffold { innerPadding ->
+                        HistoryDetailScreen(
+                            modifier = Modifier.padding(innerPadding),
+                            groupName = state.groupName,
+                            keyword = GroupKeyword.getKeyword(state.keyword),
+                            item = state.history,
+                            onClickBackButton = { finish() },
+                            onClickShareButton = { bitmap -> shareBitmap(bitmap) },
+                        )
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -64,13 +64,18 @@ fun HistoryDetailScreen(
             style = PicTypography.bodyMedium16,
             color = Color(0xFFB3B3B3), // Todo : 추후 Design System 색상값 받기
         )
-        HistoryPhotoCard(
-            modifier = Modifier
-                .weight(1f)
-                .captureIntoCanvas(picture),
-            keyword = keyword,
-            item = item,
-        )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            HistoryPhotoCard(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .captureIntoCanvas(picture),
+                keyword = keyword,
+                item = item,
+            )
+        }
         PicNormalButton(
             modifier = Modifier
                 .padding(bottom = 19.dp)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -1,28 +1,34 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
+import android.graphics.Bitmap
+import android.graphics.Picture
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
+import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicBackButtonTopBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicPhotoCardFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTopBarTitleAlign
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
@@ -30,33 +36,56 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.Ca
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.captureIntoCanvas
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.createBitmap
 
 @Composable
 fun HistoryDetailScreen(
+    modifier: Modifier,
     groupName: String,
     keyword: GroupKeyword,
     item: HistoryItem,
     onClickBackButton: () -> Unit,
+    onClickShareButton: (Bitmap) -> Unit,
 ) {
+    val picture = remember { Picture() }
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .background(color = Color.Black),
+            .background(Color(0xFF555555)),
     ) {
         PicBackButtonTopBar(
             modifier = Modifier
-                .background(Gray0.copy(alpha = 0.1f))
-                .padding(top = 56.dp),
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(top = 16.dp, start = 16.dp, end = 16.dp),
             isLightMode = false,
             titleText = groupName,
             titleAlign = PicTopBarTitleAlign.LEFT,
             backButtonClicked = onClickBackButton,
         )
+        Text(
+            modifier = Modifier.padding(start = 46.dp),
+            text = "2024.05.24",
+            style = PicTypography.bodyMedium16,
+            color = Color(0xFFB3B3B3),
+        )
         HistoryPhotoCard(
             modifier = Modifier
-                .weight(1f),
+                .weight(1f)
+                .captureIntoCanvas(picture),
             keyword = keyword,
             item = item,
+        )
+        PicNormalButton(
+            modifier = Modifier
+                .padding(bottom = 19.dp)
+                .align(Alignment.CenterHorizontally),
+            iconRes = R.drawable.ic_share,
+            onButtonClicked = {
+                val bitmap = picture.createBitmap()
+                onClickShareButton(bitmap)
+            },
         )
     }
 }
@@ -127,6 +156,7 @@ private fun GridPhotoSection(
 private fun HistoryDetailScreenPreview() {
     SharedAlbumTheme {
         HistoryDetailScreen(
+            modifier = Modifier,
             groupName = "가빵집",
             keyword = GroupKeyword.CREW,
             item = HistoryItem(
@@ -155,6 +185,7 @@ private fun HistoryDetailScreenPreview() {
                 ),
             ),
             onClickBackButton = {},
+            onClickShareButton = {},
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -62,7 +62,7 @@ fun HistoryDetailScreen(
             modifier = Modifier.padding(start = 46.dp),
             text = "2024.05.24",
             style = PicTypography.bodyMedium16,
-            color = Color(0xFFB3B3B3),
+            color = Color(0xFFB3B3B3), // Todo : 추후 Design System 색상값 받기
         )
         HistoryPhotoCard(
             modifier = Modifier

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -2,12 +2,10 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
 import android.graphics.Bitmap
 import android.graphics.Picture
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -49,11 +47,7 @@ fun HistoryDetailScreen(
     onClickShareButton: (Bitmap) -> Unit,
 ) {
     val picture = remember { Picture() }
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(Color(0xFF555555)),
-    ) {
+    Column(modifier = modifier) {
         PicBackButtonTopBar(
             modifier = Modifier
                 .fillMaxWidth()

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupmember/GroupMemberScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupmember/GroupMemberScreen.kt
@@ -84,7 +84,10 @@ private fun GroupMemberScreen(
             .background(Gray0),
     ) {
         PicBackButtonTopBar(
-            modifier = Modifier.padding(top = 16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(top = 30.dp, bottom = 14.dp, start = 16.dp, end = 16.dp),
             titleText = stringResource(id = R.string.group_member_list_title),
             backButtonClicked = onClickBackButton,
         )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/mypage/MyPageScreen.kt
@@ -138,6 +138,10 @@ fun MyPageScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         PicBackButtonTopBar(
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .padding(vertical = 14.dp, horizontal = 16.dp),
             titleText = stringResource(id = R.string.my_page),
             backButtonClicked = onClickBack,
         )


### PR DESCRIPTION
## Issue No
- close #289 

## Overview (Required)
- 히스토리 상세화면 사진공유 기능 추가

## Links
- https://www.figma.com/design/kZd5C2Mgr2NHKYvefeztSu/Design-file?node-id=397-9769&t=yjBxTLJDwZHJZCZa-4

## ScreenShots
https://github.com/user-attachments/assets/e1f634ca-97cc-4c5e-927a-f883188c5fdc

