### PR TITLE
[#281] 모든 단일/네컷 사진에 placeholder 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicPhotoCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -203,6 +204,7 @@ fun PicCroppedPhoto(
                 .build(),
             contentScale = ContentScale.Crop,
             contentDescription = stringResource(R.string.group_main_picture),
+            placeholder = ColorPainter(Gray0),
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
@@ -53,6 +54,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray20
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
@@ -371,6 +373,7 @@ private fun FrontCardImage(
             model = imageUrl,
             contentScale = ContentScale.Crop,
             contentDescription = stringResource(R.string.group_main_picture),
+            placeholder = ColorPainter(Gray0),
         )
         StableImage(
             modifier = Modifier.aspectRatio(1f),


### PR DESCRIPTION
## Issue No
- close #281 

## Overview (Required)
- 이미지 placeholder 적용
- 인생네컷이랑, 한장짜리 있는 곳도 Placeholder 적용 안된곳 적용시키기
- 흰색으로 넣어주는 것으로 협의 완료

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/a2099214-d6df-4133-a890-bd20512fc1ff" width="300" /> | <img src="https://github.com/user-attachments/assets/f34a638c-e91b-480b-9173-8b3c2b10bc47" width="300" />

## video
https://github.com/user-attachments/assets/d105dd87-f83b-498e-9adf-55a731ae6f33

