### PR TITLE
[#305] BottomSheetScaffold 를 사용할 때 실 디자인과 실제 앱이 다르게 나오는 점 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -3,7 +3,7 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 import android.graphics.Bitmap
 import android.util.Log
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -142,18 +142,6 @@ fun GroupDetailScreen(
 
         BottomSheetScaffold(
             modifier = modifier,
-            topBar = {
-                PicBackButtonTopBar(
-                    modifier = Modifier.fillMaxWidth().padding(top = 40.dp),
-                    titleText = state.groupInfo?.name.orEmpty(),
-                    titleAlign = PicTopBarTitleAlign.LEFT,
-                    backButtonClicked = onClickBackButton,
-                    rightIcon1 = if (state.isEnabledNewEvent) PicTopBarIcon.PLUS else null,
-                    rightIcon2 = PicTopBarIcon.GROUP_MEMBER,
-                    rightIcon1Clicked = onClickEventMake,
-                    rightIcon2Clicked = onClickGroupMemberButton,
-                )
-            },
             scaffoldState = scaffoldState,
             sheetShadowElevation = sheetElevation,
             sheetPeekHeight = 250.dp,
@@ -171,20 +159,31 @@ fun GroupDetailScreen(
                 )
             },
         ) {
-            RecentEventContainer(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Gray0)
-                    .verticalScroll(rememberScrollState())
-                    .padding(top = 10.dp, bottom = 270.dp),
-                status = state.status,
-                event = state.recentEvent,
-                keyword = state.groupInfo?.keyword ?: GroupKeyword.SCHOOL,
-                cardFrontImageUrl = state.groupInfo?.cardFrontImageUrl.orEmpty(),
-                images = ImmutableList(state.groupInfo?.cardBackImages.orEmpty()),
-                onClickActionButton = onClickActionButton,
-                onClickShareButton = onClickShareButton,
-            )
+            Column {
+                PicBackButtonTopBar(
+                    modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                    titleText = state.groupInfo?.name.orEmpty(),
+                    titleAlign = PicTopBarTitleAlign.LEFT,
+                    backButtonClicked = onClickBackButton,
+                    rightIcon1 = if (state.isEnabledNewEvent) PicTopBarIcon.PLUS else null,
+                    rightIcon2 = PicTopBarIcon.GROUP_MEMBER,
+                    rightIcon1Clicked = onClickEventMake,
+                    rightIcon2Clicked = onClickGroupMemberButton,
+                )
+                RecentEventContainer(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(bottom = 270.dp),
+                    status = state.status,
+                    event = state.recentEvent,
+                    keyword = state.groupInfo?.keyword ?: GroupKeyword.SCHOOL,
+                    cardFrontImageUrl = state.groupInfo?.cardFrontImageUrl.orEmpty(),
+                    images = ImmutableList(state.groupInfo?.cardBackImages.orEmpty()),
+                    onClickActionButton = onClickActionButton,
+                    onClickShareButton = onClickShareButton,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue No
- close #305 

## Overview (Required)
- GroupDetail 화면 들어가보면 TopBar 와 네컷사진 사이 공간이 너무 많은 것 같음. (실제로 비교해보면 조금 다름)
- background 강제로 주고 확인해보니 실제로 BottomSheetScaffold 의 topBar 에 넣어주면 content 사이에 의도하지 않은 공간이 생기는 것을 확인하였음

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/25942337-2b09-4cd8-ae65-5fc6ac6ff2a6" width="300" /> | <img src="https://github.com/user-attachments/assets/029f3f1a-4fcc-4fc3-9250-7e2119929402" width="300" />
