### PR TITLE
[#307] 그룹썸네일 화면, 그룹생성완료 화면에 placeholder 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -23,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0Alpha80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
@@ -162,6 +164,7 @@ private fun ThumbnailCard(
             model = groupCreationResult.imageUrl,
             contentDescription = stringResource(id = R.string.thumbnail_image),
             contentScale = ContentScale.Crop,
+            placeholder = ColorPainter(Gray0),
         )
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/thumbnail/GroupCreationThumbnailScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -208,6 +209,7 @@ private fun ThumbnailCard(
                 model = thumbnailUri,
                 contentDescription = stringResource(id = R.string.thumbnail_image),
                 contentScale = ContentScale.Crop,
+                placeholder = ColorPainter(Gray0),
             )
             if (modifyButtonEnabled) {
                 CardCoverIcon(


### PR DESCRIPTION
## Issue No
- close #307 

## Overview (Required)
- 그룹썸네일 화면, 그룹생성완료 화면에 placeholder 추가

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/8e877c02-90f4-4241-86db-4374fe8b9236" width="300" /> | <img src="https://github.com/user-attachments/assets/77eeeca4-5cad-4379-9fd3-f3960bebf2ef" width="300" />
<img src="https://github.com/user-attachments/assets/16ba0283-35c2-4528-ac63-7573b54cd89d" width="300" /> | <img src="https://github.com/user-attachments/assets/42eef7ed-9cff-4bbd-b56b-408be5a605fd" width="300" />


https://github.com/user-attachments/assets/916ae4a6-441b-45e6-b64a-beb535b4f714

