### PR TITLE
[#302] PicTag 공통로직으로 다시 모아주기

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTag.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/common/PicTag.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -29,6 +30,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Malibu
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.noRippleClickable
 
 @Composable
 fun PicTag(
@@ -37,9 +39,26 @@ fun PicTag(
     textStyle: TextStyle = PicTypography.bodyMedium12,
     @DrawableRes iconRes: Int? = null,
     iconColor: Color = Gray50,
+    backgroundColor: Color = Gray40,
     textColor: Color = Gray80,
+    innerPadding: PaddingValues = PaddingValues(horizontal = 10.dp, vertical = 6.dp),
+    onClick: (() -> Unit)? = null,
 ) {
-    Box(modifier = modifier) {
+    Box(
+        modifier = modifier
+            .background(
+                color = backgroundColor,
+                shape = RoundedCornerShape(20.dp),
+            )
+            .run {
+                if (onClick != null) {
+                    noRippleClickable(onClick = onClick)
+                } else {
+                    this
+                }
+            }
+            .padding(innerPadding),
+    ) {
         Row(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -69,23 +88,14 @@ fun PicTagPreview() {
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
             PicTag(
-                modifier = Modifier
-                    .background(color = Gray40, RoundedCornerShape(20.dp))
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
                 text = "쉿, 투표중",
             )
             PicTag(
-                modifier = Modifier
-                    .background(color = Gray40, RoundedCornerShape(20.dp))
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
                 text = "학교",
                 iconRes = R.drawable.ic_kakao,
                 iconColor = Malibu,
             )
             PicTag(
-                modifier = Modifier
-                    .background(color = Gray40, RoundedCornerShape(20.dp))
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
                 text = "학교",
                 iconRes = R.drawable.ic_kakao,
                 iconColor = Malibu,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/ThumbnailCardFrame.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/common/ThumbnailCardFrame.kt
@@ -1,12 +1,10 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.groupcreation.common
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -43,13 +41,12 @@ fun ThumbnailCardFrame(
             modifier = Modifier
                 .wrapContentSize()
                 .padding(top = 25.dp)
-                .align(Alignment.TopCenter)
-                .background(color = Gray80, RoundedCornerShape(20.dp))
-                .padding(horizontal = 10.dp, vertical = 6.dp),
+                .align(Alignment.TopCenter),
             text = stringResource(id = keyword.tagNameResId),
             iconRes = keyword.symbolResId,
             iconColor = keyword.symbolColor,
             textColor = Gray0,
+            backgroundColor = Gray80,
         )
         Text(
             modifier = Modifier

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/GroupHomeScreen.kt
@@ -235,18 +235,15 @@ private fun TagFilter(
             PicTag(
                 modifier = Modifier
                     .wrapContentSize()
-                    .padding(vertical = 3.5.dp)
-                    .background(
-                        color = if (tagInfo.isSelected) Gray100 else Gray40,
-                        shape = RoundedCornerShape(20.dp),
-                    )
-                    .noRippleClickable { onTagClicked(tagInfo) }
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                    .padding(vertical = 3.5.dp),
                 text = stringResource(id = tagInfo.tagNameResId),
                 iconRes = tagInfo.symbolResId,
                 iconColor = tagInfo.symbolColor,
                 textColor = if (tagInfo.isSelected) Gray0 else Gray80,
                 textStyle = PicTypography.headBold14,
+                backgroundColor = if (tagInfo.isSelected) Gray100 else Gray40,
+                innerPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                onClick = { onTagClicked(tagInfo) },
             )
         }
     }
@@ -406,18 +403,12 @@ private fun GroupTag(
 ) {
     Row(modifier = modifier) {
         PicTag(
-            modifier = Modifier
-                .padding(end = 6.dp)
-                .background(color = Gray40, RoundedCornerShape(20.dp))
-                .padding(horizontal = 10.dp, vertical = 6.dp),
+            modifier = Modifier.padding(end = 6.dp),
             text = stringResource(id = keyword.tagNameResId),
             iconRes = keyword.symbolResId,
             iconColor = keyword.symbolColor,
         )
         PicTag(
-            modifier = Modifier
-                .background(color = Gray40, RoundedCornerShape(20.dp))
-                .padding(horizontal = 10.dp, vertical = 6.dp),
             text = statusDesc,
         )
     }


### PR DESCRIPTION
## Issue No
- close #302 

## Overview (Required)
- PicTag 공통화 로직으로 다시 모으기
- PicTag 에 늘어나봐야 그렇게 인자가 많이 안늘어날 것 같아서, 같이 가져가는 식으로 다시 모아주었습니다
- 확실히 사용처에서는 중복코드가 사라져서 깔끔해지긴 한 것 같긴한데, 더 좋은 아이디어가 보인다면 마음편히 의견 부탁드립니다~
