### PR TITLE
[#308] 현재 존재하는 태그들만 노출되도록 수정

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/FilterTag.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/grouphome/model/FilterTag.kt
@@ -15,22 +15,22 @@ data class FilterTag(
     val isSelected: Boolean,
 ) {
     companion object {
-        fun getTotalFilter() = FilterTag(
+        fun getTotalFilter(isSelected: Boolean = false) = FilterTag(
             name = GroupKeyword.TOTAL,
             symbolResId = null,
             symbolColor = Gray100,
             tagNameResId = R.string.tag_total,
-            isSelected = true,
+            isSelected = isSelected,
         )
     }
 }
 
-fun GroupKeyword.toFilterTag() = FilterTag(
+fun GroupKeyword.toFilterTag(isSelected: Boolean = false) = FilterTag(
     name = name,
     symbolResId = symbolResId,
     symbolColor = symbolColor,
     tagNameResId = tagNameResId,
-    isSelected = false,
+    isSelected = isSelected,
 )
 
 fun List<GroupKeyword>.toFilterTagList() = map { it.toFilterTag() }


### PR DESCRIPTION
## Issue No
- close #308 

## Overview (Required)
- 그룹이 없을때는 태그가 보여지지 않도록 구현

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/7d81233b-1a38-4556-833a-33bf00957aab" width="300" /> | <img src="https://github.com/user-attachments/assets/00ea67d2-237d-48c9-a0f1-a77fbf1ad268" width="300" />

## Video

https://github.com/user-attachments/assets/193eacda-f31a-4be3-a18f-3f8275617766

