### PR TITLE
[#312] Compose Navigation Stack 비워졌을 때 Activity 종료하도록 코드 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/GroupCreationActivity.kt
@@ -33,6 +33,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.invitation.InvitationCo
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.MainActivity
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.FileUtil
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.PicPhotoPicker
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.canNavigateBack
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -55,6 +56,7 @@ class GroupCreationActivity : ComponentActivity() {
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             val groupCreationState by viewModel.uiState.collectAsStateWithLifecycle()
+            val navController = rememberNavController()
             SharedAlbumTheme {
                 Scaffold(
                     snackbarHost = {
@@ -67,7 +69,7 @@ class GroupCreationActivity : ComponentActivity() {
                             .padding(contentPadding)
                             .consumeWindowInsets(contentPadding)
                             .systemBarsPadding(),
-                        navController = rememberNavController(),
+                        navController = navController,
                         startDestination = GroupCreationRoute.initRoute,
                         groupCreationUiState = groupCreationState,
                         navigateToInvitationCode = {
@@ -100,6 +102,13 @@ class GroupCreationActivity : ComponentActivity() {
                         },
                         showSnackBarMessage = { type: PicSnackbarType, message: String ->
                             viewModel.showSnackBar(type, message)
+                        },
+                        onBackButtonClicked = {
+                            if (navController.canNavigateBack()) {
+                                navController.popBackStack()
+                            } else {
+                                finish()
+                            }
                         },
                     )
                 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/navigation/GroupCreationNavHost.kt
@@ -32,6 +32,7 @@ fun GroupCreationNavHost(
     createGroup: () -> Unit,
     finishGroupCreation: () -> Unit,
     showSnackBarMessage: (type: PicSnackbarType, message: String) -> Unit,
+    onBackButtonClicked: () -> Unit,
 ) {
     NavHost(
         modifier = modifier,
@@ -46,7 +47,7 @@ fun GroupCreationNavHost(
         )
         groupCreationNameNavGraph(
             initialName = groupCreationUiState.name,
-            onBackButtonClicked = { navController.popBackStack() },
+            onBackButtonClicked = onBackButtonClicked,
             onNextButtonClicked = { name ->
                 navController.navigateToGroupCreationKeyword()
                 updateName(name)
@@ -54,7 +55,7 @@ fun GroupCreationNavHost(
         )
         groupCreationKeywordNavGraph(
             initialKeyword = groupCreationUiState.keyword,
-            onBackButtonClicked = { navController.popBackStack() },
+            onBackButtonClicked = onBackButtonClicked,
             onNextButtonClicked = { keyword ->
                 navController.navigateToGroupCreationThumbnail()
                 updateKeyword(keyword)
@@ -62,7 +63,7 @@ fun GroupCreationNavHost(
         )
         groupCreationThumbnailNavGraph(
             state = groupCreationUiState,
-            onBackButtonClicked = { navController.popBackStack() },
+            onBackButtonClicked = onBackButtonClicked,
             onNextButtonClicked = createGroup,
             onGetThumbnailButtonClicked = onGetThumbnailButtonClicked,
             navigateNextScreen = { navController.navigateToGroupCreationComplete() },

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/MainActivity.kt
@@ -42,6 +42,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.navigation.MainNav
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.navigation.MainRoute
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.FileUtil
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.PicPhotoPicker
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.canNavigateBack
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.shareBitmap
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -108,6 +109,13 @@ class MainActivity : ComponentActivity() {
                         onSnackbarRequired = { type, message ->
                             coroutineScope.launch {
                                 snackbarHostState.showPicSnackbar(type, message)
+                            }
+                        },
+                        onClickBackButton = {
+                            if (navController.canNavigateBack()) {
+                                navController.popBackStack()
+                            } else {
+                                finish()
                             }
                         },
                     )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/navigation/MainNavHost.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/navigation/MainNavHost.kt
@@ -35,6 +35,7 @@ fun MainNavHost(
     onClickSendFcmButton: (eventId: Long) -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
     onSnackbarRequired: (PicSnackbarType, String) -> Unit,
+    onClickBackButton: () -> Unit,
 ) {
     val context = LocalContext.current
 
@@ -61,7 +62,7 @@ fun MainNavHost(
             onClickGroupMemberButton = { id, keyword ->
                 navController.navigateGroupMember(id, keyword)
             },
-            onClickBackButton = { navController.popBackStack() },
+            onClickBackButton = onClickBackButton,
             onClickOpenPhotoPickerButton = onClickOpenPhotoPickerButton,
             onClickSendFcmButton = onClickSendFcmButton,
             onClickVoteButton = { eventId -> VoteActivity.openActivity(context, eventId) },
@@ -74,12 +75,12 @@ fun MainNavHost(
         )
         groupMemberNavGraph(
             innerPadding = innerPadding,
-            onClickBackButton = { navController.popBackStack() },
+            onClickBackButton = onClickBackButton,
             onShowSnackbar = onSnackbarRequired,
         )
         myPageNavGraph(
             innerPadding = innerPadding,
-            onClickBack = { navController.popBackStack() },
+            onClickBack = onClickBackButton,
             onClickNotificationSetting = {
                 context.startActivity(
                     Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/NavControllerExt.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/NavControllerExt.kt
@@ -1,0 +1,5 @@
+package com.mashup.gabbangzip.sharedalbum.presentation.utils
+
+import androidx.navigation.NavController
+
+fun NavController.canNavigateBack() = previousBackStackEntry != null


### PR DESCRIPTION
## Issue No
- close #312 

## Overview (Required)
- Compose Navigation Stack 비워졌을 때 Activity 종료하도록 코드 추가
- 타이밍 맞춰서 뒤로가기 두번 누르면 아무리 debounce 를 걸어두었더라도 두번 클릭이 적용된다 (ㅠㅠ)

## Video

https://github.com/user-attachments/assets/c0fcd561-9cc8-4954-ac49-dfda39445e8e

**Before**

<br>
<br>

https://github.com/user-attachments/assets/9220fe18-e509-4e1d-9ca6-9745ad002aaf

**After**