### PR TITLE
[#289] 히스토리 상세화면 공유하기 기능 추가

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.shareBitmap
 
 class HistoryDetailActivity : ComponentActivity() {
     private val state by lazy { intent.getSerializableExtra(KEY_HISTORY) as HistoryDetailState? }
@@ -29,6 +30,7 @@ class HistoryDetailActivity : ComponentActivity() {
                         keyword = GroupKeyword.getKeyword(state.keyword),
                         item = state.history,
                         onClickBackButton = { finish() },
+                        onClickShareButton = { bitmap -> shareBitmap(bitmap) },
                     )
                 }
             }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -1,5 +1,7 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
+import android.graphics.Bitmap
+import android.graphics.Picture
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,16 +15,19 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicBackButtonTopBar
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicCroppedPhoto
+import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicNormalButton
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicPhotoCardFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicTopBarTitleAlign
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail.model.HistoryItem
@@ -30,6 +35,8 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.Ca
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.captureIntoCanvas
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.createBitmap
 
 @Composable
 fun HistoryDetailScreen(
@@ -37,7 +44,9 @@ fun HistoryDetailScreen(
     keyword: GroupKeyword,
     item: HistoryItem,
     onClickBackButton: () -> Unit,
+    onClickShareButton: (Bitmap) -> Unit,
 ) {
+    val picture = remember { Picture() }
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -52,11 +61,28 @@ fun HistoryDetailScreen(
             titleAlign = PicTopBarTitleAlign.LEFT,
             backButtonClicked = onClickBackButton,
         )
-        HistoryPhotoCard(
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            HistoryPhotoCard(
+                modifier = Modifier
+                    .wrapContentSize()
+                    .captureIntoCanvas(picture),
+                keyword = keyword,
+                item = item,
+            )
+        }
+        PicNormalButton(
             modifier = Modifier
-                .weight(1f),
-            keyword = keyword,
-            item = item,
+                .padding(bottom = 79.dp)
+                .align(Alignment.CenterHorizontally),
+            iconRes = R.drawable.ic_share,
+            isSingleClick = true,
+            onButtonClicked = {
+                val bitmap = picture.createBitmap()
+                onClickShareButton(bitmap)
+            },
         )
     }
 }
@@ -155,6 +181,7 @@ private fun HistoryDetailScreenPreview() {
                 ),
             ),
             onClickBackButton = {},
+            onClickShareButton = {},
         )
     }
 }


### PR DESCRIPTION
## Issue No
- close #289 

## Overview (Required)
- 히스토리 상세화면 공유하기 기능 추가

## Links
- https://www.figma.com/design/kZd5C2Mgr2NHKYvefeztSu/Design-file?node-id=4406-21730&t=6Mec476HPTUAytGA-4

## Screenshot
https://github.com/user-attachments/assets/4b920674-0021-4124-b588-09e118183cb3

