### PR TITLE
[#250] 네컷사진 간헐적으로 노출 안되는 이슈

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailRecentEvent.kt
@@ -201,27 +201,29 @@ private fun PhotoCard(
             keywordType = keyword,
             frameResId = PicPhotoFrame.getTypeByKeyword(keyword.name).frameResId,
         )
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                modifier = Modifier
-                    .padding(top = 30.dp),
-                text = date,
-                color = Gray80,
-                style = PicTypography.bodyMedium16,
-            )
-            PicFourPhotoGrid(
-                modifier = Modifier
-                    .padding(top = 28.dp, bottom = 23.dp, start = 30.dp, end = 30.dp),
-                backgroundColor = keyword.frontCardBackgroundColor,
-                images = images,
-            )
-            Text(
-                modifier = Modifier.padding(bottom = 48.dp),
-                text = title,
-                color = Gray80,
-                style = PicTypography.headBold20,
-            )
-        }
+        Text(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 25.dp),
+            text = date,
+            color = Gray80,
+            style = PicTypography.bodyMedium16,
+        )
+        PicFourPhotoGrid(
+            modifier = Modifier
+                .padding(top = 85.dp, bottom = 85.dp, start = 30.dp, end = 30.dp)
+                .align(Alignment.Center),
+            backgroundColor = keyword.frontCardBackgroundColor,
+            images = images,
+        )
+        Text(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 31.dp),
+            text = title,
+            color = Gray80,
+            style = PicTypography.headBold20,
+        )
     }
 }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/HistoryDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.main.groupdetail
 
 import android.graphics.Bitmap
-import android.graphics.Picture
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,7 +14,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,8 +34,9 @@ import com.mashup.gabbangzip.sharedalbum.presentation.ui.main.grouphome.model.Ca
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.GroupKeyword
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.model.PicPhotoFrame
 import com.mashup.gabbangzip.sharedalbum.presentation.utils.ImmutableList
-import com.mashup.gabbangzip.sharedalbum.presentation.utils.captureIntoCanvas
-import com.mashup.gabbangzip.sharedalbum.presentation.utils.createBitmap
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.capturable
+import com.mashup.gabbangzip.sharedalbum.presentation.utils.rememberCaptureController
+import kotlinx.coroutines.launch
 
 @Composable
 fun HistoryDetailScreen(
@@ -46,7 +46,8 @@ fun HistoryDetailScreen(
     onClickBackButton: () -> Unit,
     onClickShareButton: (Bitmap) -> Unit,
 ) {
-    val picture = remember { Picture() }
+    val captureController = rememberCaptureController()
+    val coroutineScope = rememberCoroutineScope()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -68,7 +69,7 @@ fun HistoryDetailScreen(
             HistoryPhotoCard(
                 modifier = Modifier
                     .wrapContentSize()
-                    .captureIntoCanvas(picture),
+                    .capturable(captureController),
                 keyword = keyword,
                 item = item,
             )
@@ -80,8 +81,10 @@ fun HistoryDetailScreen(
             iconRes = R.drawable.ic_share,
             isSingleClick = true,
             onButtonClicked = {
-                val bitmap = picture.createBitmap()
-                onClickShareButton(bitmap)
+                coroutineScope.launch {
+                    val bitmap = captureController.captureAsync().await()
+                    onClickShareButton(bitmap)
+                }
             },
         )
     }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/CaptureBitmapUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/CaptureBitmapUtil.kt
@@ -1,51 +1,178 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.utils
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Picture
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.CacheDrawModifierNode
 import androidx.compose.ui.graphics.drawscope.draw
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.node.DelegatableNode
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
 import androidx.core.content.FileProvider
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
 import androidx.compose.ui.graphics.Canvas as ComposeCanvas
 
-fun Modifier.captureIntoCanvas(
-    picture: Picture,
-): Modifier = this.then(
-    drawWithCache {
-        // Example that shows how to redirect rendering to an Android Picture and then
-        // draw the picture into the original destination
-        val width = this.size.width.toInt()
-        val height = this.size.height.toInt()
-        onDrawWithContent {
-            val pictureCanvas = ComposeCanvas(
-                picture.beginRecording(
-                    width,
-                    height,
-                ),
-            )
-            draw(this, this.layoutDirection, pictureCanvas, this.size) {
-                this@onDrawWithContent.drawContent()
-            }
-            picture.endRecording()
+/**
+ * [CaptureController.captureAsync] 를 호출했을 때 현재 Composable 의 [Bitmap] 을 반환하는 유틸 함수
+ *
+ * modifier 안으로 [Picture] 객체를 전달하는 일반적인 방식은 Composable 함수 내부에 [AsyncImage] 가 있을 때
+ * AsyncImage 가 로드되기 전에 [Picture] 객체에 그림을 그려버리는 문제점이 발생함
+ *
+ * compose 1.7.0-alpha07 이상 (compose-bom 2024.09.01 이상) 부터는 [rememberGraphicsLayer] 을 제공 하고
+ * 있어서, compose-bom 2024.09.01 이후엔 이를 활용 해보는 것도 좋아보임
+ *
+ * @see (https://blog.shreyaspatil.dev/capturing-composable-to-a-bitmap-without-losing-a-state)[link]
+ * @see (https://github.com/PatilShreyas/Capturable/tree/master)[reference]
+ */
+fun Modifier.capturable(controller: CaptureController): Modifier {
+    return this then CapturableModifierNodeElement(controller)
+}
 
-            drawIntoCanvas { canvas -> canvas.nativeCanvas.drawPicture(picture) }
+@SuppressLint("ModifierNodeInspectableProperties")
+private data class CapturableModifierNodeElement(
+    private val controller: CaptureController
+) : ModifierNodeElement<CapturableModifierNode>() {
+    override fun create(): CapturableModifierNode {
+        return CapturableModifierNode(controller)
+    }
+
+    override fun update(node: CapturableModifierNode) {
+        node.updateController(controller)
+    }
+}
+
+private class CapturableModifierNode(
+    controller: CaptureController
+) : DelegatingNode(), DelegatableNode {
+
+    /**
+     * State to hold the current [CaptureController] instance.
+     * This can be updated via [updateController] method.
+     */
+    private val currentController = MutableStateFlow(controller)
+
+    override fun onAttach() {
+        super.onAttach()
+        coroutineScope.launch {
+            observeCaptureRequestsAndServe()
         }
-    },
-)
+    }
 
-fun Picture.createBitmap(): Bitmap {
+    /**
+     * Sets new [CaptureController]
+     */
+    fun updateController(newController: CaptureController) {
+        currentController.value = newController
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun observeCaptureRequestsAndServe() {
+        currentController
+            .flatMapLatest { it.captureRequests }
+            .collect { request ->
+                val completable = request.imageBitmapDeferred
+                try {
+                    val picture = getCurrentContentAsPicture()
+                    val bitmap = withContext(Dispatchers.Default) {
+                        picture.createBitmap(request.config)
+                    }
+                    completable.complete(bitmap)
+                } catch (error: Throwable) {
+                    completable.completeExceptionally(error)
+                }
+            }
+    }
+
+    private suspend fun getCurrentContentAsPicture(): Picture {
+        return Picture().apply { drawCanvasIntoPicture(this) }
+    }
+
+    /**
+     * Draws the current content into the provided [picture]
+     */
+    private suspend fun drawCanvasIntoPicture(picture: Picture) {
+        // CompletableDeferred to wait until picture is drawn from the Canvas content
+        val pictureDrawn = CompletableDeferred<Unit>()
+
+        // Delegate the task to draw the content into the picture
+        val delegatedNode = delegate(
+            CacheDrawModifierNode {
+                val width = this.size.width.toInt()
+                val height = this.size.height.toInt()
+
+                onDrawWithContent {
+                    val pictureCanvas = ComposeCanvas(picture.beginRecording(width, height))
+
+                    draw(this, this.layoutDirection, pictureCanvas, this.size) {
+                        this@onDrawWithContent.drawContent()
+                    }
+                    picture.endRecording()
+
+                    drawIntoCanvas { canvas ->
+                        canvas.nativeCanvas.drawPicture(picture)
+
+                        // Notify that picture is drawn
+                        pictureDrawn.complete(Unit)
+                    }
+                }
+            }
+        )
+        // Wait until picture is drawn
+        pictureDrawn.await()
+
+        // As task is accomplished, remove the delegation of node to prevent draw operations on UI
+        // updates or recompositions.
+        undelegate(delegatedNode)
+    }
+}
+
+class CaptureController {
+    private val _captureRequests = MutableSharedFlow<CaptureRequest>(extraBufferCapacity = 1)
+    internal val captureRequests = _captureRequests.asSharedFlow()
+
+    fun captureAsync(config: Bitmap.Config = Bitmap.Config.ARGB_8888): Deferred<Bitmap> {
+        val deferredImageBitmap = CompletableDeferred<Bitmap>()
+        return deferredImageBitmap.also {
+            _captureRequests.tryEmit(CaptureRequest(imageBitmapDeferred = it, config = config))
+        }
+    }
+
+    internal class CaptureRequest(
+        val imageBitmapDeferred: CompletableDeferred<Bitmap>,
+        val config: Bitmap.Config
+    )
+}
+
+@Composable
+fun rememberCaptureController(): CaptureController {
+    return remember { CaptureController() }
+}
+
+fun Picture.createBitmap(config: Bitmap.Config = Bitmap.Config.ARGB_8888): Bitmap {
     val bitmap = Bitmap.createBitmap(
         width,
         height,
-        Bitmap.Config.ARGB_8888,
+        config,
     )
 
     val canvas = Canvas(bitmap)

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/CaptureBitmapUtil.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/utils/CaptureBitmapUtil.kt
@@ -50,7 +50,7 @@ fun Modifier.capturable(controller: CaptureController): Modifier {
 
 @SuppressLint("ModifierNodeInspectableProperties")
 private data class CapturableModifierNodeElement(
-    private val controller: CaptureController
+    private val controller: CaptureController,
 ) : ModifierNodeElement<CapturableModifierNode>() {
     override fun create(): CapturableModifierNode {
         return CapturableModifierNode(controller)
@@ -62,7 +62,7 @@ private data class CapturableModifierNodeElement(
 }
 
 private class CapturableModifierNode(
-    controller: CaptureController
+    controller: CaptureController,
 ) : DelegatingNode(), DelegatableNode {
 
     /**
@@ -135,7 +135,7 @@ private class CapturableModifierNode(
                         pictureDrawn.complete(Unit)
                     }
                 }
-            }
+            },
         )
         // Wait until picture is drawn
         pictureDrawn.await()
@@ -159,7 +159,7 @@ class CaptureController {
 
     internal class CaptureRequest(
         val imageBitmapDeferred: CompletableDeferred<Bitmap>,
-        val config: Bitmap.Config
+        val config: Bitmap.Config,
     )
 }
 


### PR DESCRIPTION
## Issue No
- close #250 

## Overview (Required)
- 네컷사진 간헐적으로 노출 안되는 이슈
- 처음 앱 들어와서 그룹상세화면 들어갔을때 재현됨
- 히스토리 상세도 문제의 원인이었던 `captureIntoCanvas` 를 사용할 예정이어서 요거 머지한 다음에 머지할게요~ 
 => #318 

## 원인
- 원인은 Composable 을 bitmap 으로 변경하기 위한 `captureIntoCanvas` 함수에 있음
- `captureIntoCanvas `은 Composable 이 attach 되었을 때 인자로 전달받은 Picture 에 바로 그림을 그려주고, Picture 에 그려진 것을 Composable 에 그리는 식으로 구현되어있다.
- 여기서 사용하고있는 `drawWithCache` 는 그려둔 것을 캐시해두었다가 영역의 크기가 같거나, state 객체가 변경되지 않으면 캐시한 것을 내보내주어 그리기 횟수를 최소화하기 위한 함수이다. [(공식문서 참조링크)](https://developer.android.com/develop/ui/compose/graphics/draw/modifiers?hl=ko&_gl=1*lgld2y*_up*MQ..*_ga*Njk1Mjg0NDM3LjE3MjY5ODA2MDM.*_ga_6HH9YJMN9M*MTcyNjk4MDYwMi4xLjAuMTcyNjk4MDYwMi4wLjAuMTQ0NTAyNjk2Nw..#drawwithcache)
- `AsyncImage` 는 이미지를 비동기로 가져와서 업데이트가 되면, `AsyncImage` Composable 에 네트워크로부터 가져온 비트맵 이미지를 업데이트 하는 구조임
- 근데 이게 문제점이 AsyncImage 는 비동기로 가져와서 업데이트하는거라 우리처럼 상위 Composable 의 크기를 업데이트하지 않는 사례가 있음. 그렇다고 상위 Composable 의 state 가 바뀌는 것도 아님.
- 그러보니 우리앱은 이렇게 문제가 발생함
  - [1] attach 되자마자 AsyncImage 가 로드 되기전에 그려버림
  - [2] 그려버리기전에 이미지가 로딩되면 다행이지만, 그렇지 않으면 노출되지 않음 
  - [3] 뒤늦게 이미지가 로딩되지만, 상위 Composable 크기를 업데이트하거나 state 를 바꾸는 형태가 아니다보니 draw 를 다시 하지 않으며, 하더라도 cache 했던 미노출 화면이 보여짐
  - [4] 그래서 이미지가 로딩되었지만 노출되지 않은 이슈가 발생

## 해결방법
- 진짜 진짜 다행히 우리와 같은 상황을 마주한 사람이 있었음.
  + https://blog.shreyaspatil.dev/capturing-composable-to-a-bitmap-without-losing-a-state
- 이 사람은 Flow 가 포함된 controller 를 가지고 있는 Modifier Node 를 커스텀하여 구현함. 그래서 외부에서 `CaptureController.captureAsync` 와 같은 함수를 통해 내부 flow에 신호를 보내주면, Modifier Node 에서 flow 를 관찰하고 있다가 신호가 들어왔을 때 `captureIntoCanvas` 의 로직을 실행하고 얻은 Picture 객체를 bitmap 으로 변환하여 반환하는 식으로 구현하였음.
- 그러고서 Compose UI 쪽 issueTracker 에 해당 이슈를 등록했는데, 작년 10월에 등록했는데 아직도 검토중임. P3 라서 딴거 처리하느라 못보는 중인듯.. [(IssueTracker 참조링크)](https://issuetracker.google.com/issues/305653364)
- 그래서 저 블로그 저자가 문제를 해결하기 위해 만든 Capturable 이라는 라이브러리 소스코드를 참조해서 우리 앱에 맞게 살짝 수정해서 적용하였음
  - Capturable github link : https://github.com/PatilShreyas/Capturable/tree/master

## Screenshot

Before

https://github.com/user-attachments/assets/0c253c22-5604-4e52-9a60-ed7b738d3284

After

https://github.com/user-attachments/assets/adf84955-0270-4ffb-aae9-ab799ebeda75


