### PR TITLE
[#321] 다크모드 일부 누락된 색상 적용

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupdetail/GroupDetailScreen.kt
@@ -143,6 +143,7 @@ fun GroupDetailScreen(
         BottomSheetScaffold(
             modifier = modifier,
             scaffoldState = scaffoldState,
+            containerColor = Gray0,
             sheetShadowElevation = sheetElevation,
             sheetPeekHeight = 250.dp,
             sheetContainerColor = Gray0,
@@ -161,7 +162,9 @@ fun GroupDetailScreen(
         ) {
             Column {
                 PicBackButtonTopBar(
-                    modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
                     titleText = state.groupInfo?.name.orEmpty(),
                     titleAlign = PicTopBarTitleAlign.LEFT,
                     backButtonClicked = onClickBackButton,

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/PhotoVoteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/vote/PhotoVoteScreen.kt
@@ -43,6 +43,7 @@ import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray40
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.PicTypography
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicDialog
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicLoadingIndicator
@@ -223,6 +224,7 @@ private fun CancelVoteButton(
             .noRippleClickable(isSingleClick = true) { onCancelVote() },
         imageVector = Icons.Default.Close,
         contentDescription = stringResource(R.string.cancel_icon),
+        tint = Gray80,
     )
 }
 
@@ -244,6 +246,7 @@ private fun UserProfile(
             modifier = Modifier.padding(top = 4.dp),
             text = stringResource(R.string.vote_user_name, userInfo.name),
             style = PicTypography.headBold18,
+            color = Gray80,
         )
     }
 }


### PR DESCRIPTION
## Issue No
- close #321 

## Overview (Required)
- 그룹상세 BottomSheetScaffold containerColor Gray0 지정 (기본값 MaterialColorScheme 적용되어 발생한 문제)
- 투표하기 `~의 픽` 텍스트, `X` 버튼 색상 지정

## Screenshot
|Before | After|
|:--: | :--:|
|<img width="200" alt="스크린샷 2024-09-24 오전 12 33 35" src="https://github.com/user-attachments/assets/8a4a4b0a-6b59-4e23-bf59-a42715d935b0">|<img width="200" alt="스크린샷 2024-09-24 오전 12 33 10" src="https://github.com/user-attachments/assets/212ef46d-cd93-49e3-b5e0-018517c460a1">|
|<img width="184" alt="스크린샷 2024-09-24 오전 12 33 49" src="https://github.com/user-attachments/assets/03bdf6b6-79e1-4c4d-b491-da7bedada1f3">|<img width="189" alt="스크린샷 2024-09-24 오전 12 34 12" src="https://github.com/user-attachments/assets/e17dfb88-824a-4547-9667-4881f5da5ec8">|