### PR TITLE
[#287] 그룹원이 다 찬 방에 들어갔을 때, 다 찼다고 에러 명시

### DIFF
--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicApiErrorParser.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicApiErrorParser.kt
@@ -1,0 +1,40 @@
+package com.mashup.gabbangzip.sharedalbum.data.base
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import okhttp3.ResponseBody
+import retrofit2.HttpException
+
+object PicApiErrorParser {
+    private val moshi = Moshi.Builder().build()
+
+    // PicResponse의 타입을 동적으로 처리하기 위해 ParameterizedType 생성
+    private val type = Types.newParameterizedType(PicResponse::class.java, Any::class.java)
+    private val adapter = moshi.adapter<PicResponse<Any>>(type)
+
+    fun parse(e: Throwable): Throwable {
+        return when (e) {
+            is HttpException -> {
+                val error = e.response()
+                    ?.errorBody()
+                    ?.let { parseErrorResponse(it) }
+                PicApiException(error)
+            }
+
+            else -> e
+        }
+    }
+
+    private fun parseErrorResponse(errorResponseBody: ResponseBody): PicErrorResponse? {
+        return try {
+            val response = adapter.fromJson(errorResponseBody.string())
+            if (response != null && !response.isSuccess) {
+                response.errorResponse
+            } else {
+                null
+            }
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
@@ -32,7 +32,7 @@ suspend fun <T> callApi(
     execute: suspend () -> PicResponse<T>,
 ): T {
     return runCatching {
-        execute().data!!
+        execute().data ?: throw NoSuchElementException()
     }.getOrElse { e ->
         throw PicApiErrorParser.parse(e)
     }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/base/PicResponse.kt
@@ -21,8 +21,19 @@ data class PicErrorResponse(
     val message: String,
 )
 
+data class PicApiException(
+    val errorResponse: PicErrorResponse?,
+) : RuntimeException() {
+    override val message: String
+        get() = errorResponse?.message.orEmpty()
+}
+
 suspend fun <T> callApi(
     execute: suspend () -> PicResponse<T>,
 ): T {
-    return execute().data ?: throw IllegalStateException()
+    return runCatching {
+        execute().data!!
+    }.getOrElse { e ->
+        throw PicApiErrorParser.parse(e)
+    }
 }

--- a/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
+++ b/data/src/main/java/com/mashup/gabbangzip/sharedalbum/data/repository/GroupRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.mashup.gabbangzip.sharedalbum.data.dto.request.CreateGroupRequest
 import com.mashup.gabbangzip.sharedalbum.data.dto.request.EnterGroupRequest
 import com.mashup.gabbangzip.sharedalbum.data.dto.response.group.toDomainModel
 import com.mashup.gabbangzip.sharedalbum.data.service.GroupService
+import com.mashup.gabbangzip.sharedalbum.domain.base.PicException
 import com.mashup.gabbangzip.sharedalbum.domain.model.GroupParam
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.GroupDomainModel
 import com.mashup.gabbangzip.sharedalbum.domain.model.group.GroupInfoDomainModel
@@ -37,7 +38,17 @@ class GroupRepositoryImpl @Inject constructor(
 
     override suspend fun enterGroupByCode(code: String): Long {
         val request = EnterGroupRequest(code)
-        return callApi { groupService.enterGroupByCode(request) }.groupId
+        return runCatching {
+            callApi { groupService.enterGroupByCode(request) }.groupId
+        }.getOrElse { e ->
+            val message = e.message
+            throw when {
+                message == null -> e
+                message.contains(MESSAGE_GROUP_NOT_FOUND) -> PicException.InvalidGroupCodeException
+                message.contains(MESSAGE_GROUP_OVERFLOW) -> PicException.GroupOverflowException
+                else -> e
+            }
+        }
     }
 
     override suspend fun getGroupList(): List<GroupDomainModel> {
@@ -54,5 +65,10 @@ class GroupRepositoryImpl @Inject constructor(
 
     override suspend fun withdrawGroup(groupId: Long): WithdrawalGroupDomainModel {
         return callApi { groupService.withdrawGroup(groupId) }.toDomainModel()
+    }
+
+    companion object {
+        private const val MESSAGE_GROUP_NOT_FOUND = "해당하는 그룹을 찾을 수 없습니다"
+        private const val MESSAGE_GROUP_OVERFLOW = "인원 초과"
     }
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/base/PicException.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/base/PicException.kt
@@ -3,4 +3,6 @@ package com.mashup.gabbangzip.sharedalbum.domain.base
 sealed class PicException : Throwable() {
     data object LoginRequiredException : PicException()
     data object UnknownException : PicException()
+    data object GroupOverflowException: PicException()
+    data object InvalidGroupCodeException: PicException()
 }

--- a/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/base/PicException.kt
+++ b/domain/src/main/java/com/mashup/gabbangzip/sharedalbum/domain/base/PicException.kt
@@ -3,6 +3,6 @@ package com.mashup.gabbangzip.sharedalbum.domain.base
 sealed class PicException : Throwable() {
     data object LoginRequiredException : PicException()
     data object UnknownException : PicException()
-    data object GroupOverflowException: PicException()
-    data object InvalidGroupCodeException: PicException()
+    data object GroupOverflowException : PicException()
+    data object InvalidGroupCodeException : PicException()
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeActivity.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeActivity.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.mashup.gabbangzip.sharedalbum.presentation.R
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.SharedAlbumTheme
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.PicSnackbarHost
 import com.mashup.gabbangzip.sharedalbum.presentation.ui.common.model.PicSnackbarType
@@ -59,11 +58,13 @@ class InvitationCodeActivity : ComponentActivity() {
                 when (state.isInvitationSuccessful) {
                     true -> navigateToMainActivity()
                     false -> {
-                        LaunchedEffect(snackbarHostState) {
-                            snackbarHostState.showPicSnackbar(
-                                type = PicSnackbarType.WARNING,
-                                message = getString(R.string.enter_group_by_code_failure_message),
-                            )
+                        LaunchedEffect(state.errorMessageRes) {
+                            state.errorMessageRes?.let { message ->
+                                snackbarHostState.showPicSnackbar(
+                                    type = PicSnackbarType.WARNING,
+                                    message = getString(message),
+                                )
+                            }
                         }
                     }
 

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeUiState.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeUiState.kt
@@ -1,6 +1,9 @@
 package com.mashup.gabbangzip.sharedalbum.presentation.ui.invitation
 
+import androidx.annotation.StringRes
+
 data class InvitationCodeUiState(
     val isLoading: Boolean = false,
     val isInvitationSuccessful: Boolean? = null,
+    @StringRes val errorMessageRes: Int? = null,
 )

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeViewModel.kt
@@ -2,7 +2,9 @@ package com.mashup.gabbangzip.sharedalbum.presentation.ui.invitation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mashup.gabbangzip.sharedalbum.domain.base.PicException
 import com.mashup.gabbangzip.sharedalbum.domain.usecase.invitation.EnterGroupByInvitationCodeUseCase
+import com.mashup.gabbangzip.sharedalbum.presentation.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,7 +23,7 @@ class InvitationCodeViewModel @Inject constructor(
         _uiState.update { state ->
             state.copy(
                 isLoading = true,
-                isInvitationSuccessful = null,
+                errorMessageRes = null,
             )
         }
         viewModelScope.launch {
@@ -39,9 +41,24 @@ class InvitationCodeViewModel @Inject constructor(
                         state.copy(
                             isLoading = false,
                             isInvitationSuccessful = false,
+                            errorMessageRes = mapErrorMessageRes(e),
                         )
                     }
                 }
+        }
+    }
+
+    private fun mapErrorMessageRes(e: Throwable): Int {
+        return when (e) {
+            is PicException.InvalidGroupCodeException -> {
+                R.string.enter_group_by_code_failure_not_found
+            }
+
+            is PicException.GroupOverflowException -> {
+                R.string.enter_group_by_code_failure_overflow
+            }
+
+            else -> R.string.error_network
         }
     }
 }

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeViewModel.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/invitation/InvitationCodeViewModel.kt
@@ -50,14 +50,8 @@ class InvitationCodeViewModel @Inject constructor(
 
     private fun mapErrorMessageRes(e: Throwable): Int {
         return when (e) {
-            is PicException.InvalidGroupCodeException -> {
-                R.string.enter_group_by_code_failure_not_found
-            }
-
-            is PicException.GroupOverflowException -> {
-                R.string.enter_group_by_code_failure_overflow
-            }
-
+            is PicException.InvalidGroupCodeException -> R.string.enter_group_by_code_failure_not_found
+            is PicException.GroupOverflowException -> R.string.enter_group_by_code_failure_overflow
             else -> R.string.error_network
         }
     }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -122,7 +122,8 @@
     <string name="enter_group_by_code_title">그룹 들어가기</string>
     <string name="enter_group_by_code_input_title">초대코드를 입력해주세요</string>
     <string name="enter_group_by_code_input_hint">예) A12B0EHQ</string>
-    <string name="enter_group_by_code_failure_message">존재하지 않는 초대코드에요.</string>
+    <string name="enter_group_by_code_failure_not_found">존재하지 않는 초대코드에요.</string>
+    <string name="enter_group_by_code_failure_overflow">그룹이 가득 찼어요.</string>
 
     <string name="vote_complete_title">내 PIC을 골랐어요!</string>
     <string name="vote_complete_subtitle">모든 사람이 PIC을 완료하면\n네컷 사진이 만들어져요</string>


### PR DESCRIPTION
## Issue No
- close #287 

## Overview (Required)
- PicApiErrorParser 구현
  - 서비스에서 정의한 에러 발생 시 PicApiException 형태로 파싱해서 던지고 그외는 그대로 던집니당
<img width="829" alt="스크린샷 2024-09-28 오후 9 58 05" src="https://github.com/user-attachments/assets/de54d91c-0ae5-4832-8809-684387950638">
- 로그 라인별 설명

1.   API 에러 발생 시 응답 (`PicResponse<T>`)
2.   파싱 결과 (`PicErrorResponse`)
3.   API 에러 (존재하지 않는 코드)
4.   그외 에러 (와이파이 끄고 실행)