### PR TITLE
[#328] 초대코드 복사 문구 변경

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/groupcreation/complete/GroupCreationCompleteScreen.kt
@@ -76,7 +76,7 @@ fun GroupCreationCompleteScreen(
         content = {
             GroupCreationCompleteContent(
                 clipboardManager = LocalClipboardManager.current,
-                copyLinkMessage = stringResource(id = R.string.button_copy_link_message),
+                copyLinkMessage = stringResource(id = R.string.button_copy_code_message),
                 invitationMessage = stringResource(id = R.string.invitation_message),
                 playStoreUrl = stringResource(id = R.string.play_store_url),
                 appStoreUrl = stringResource(id = R.string.app_store_url),

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupmember/GroupMemberScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/main/groupmember/GroupMemberScreen.kt
@@ -48,7 +48,7 @@ fun GroupMemberScreen(
     viewModel: GroupMemberViewModel = hiltViewModel(),
 ) {
     val clipboardManager = LocalClipboardManager.current
-    val copyLinkMessage = stringResource(id = R.string.button_copy_link_message)
+    val copyLinkMessage = stringResource(id = R.string.button_copy_code_message)
     val invitationMessage = stringResource(id = R.string.invitation_message)
     val playStoreUrl = stringResource(id = R.string.play_store_url)
     val appStoreUrl = stringResource(id = R.string.app_store_url)

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="vote_dialog_content">페이지를 나가면\n처음부터 다시 투표 하게돼요.</string>
     <string name="vote_dialog_exit">나가기</string>
     <string name="vote_dialog_keep_vote">계속 투표하기</string>
-    <string name="button_copy_link_message">링크를 복사했어요.</string>
+    <string name="button_copy_code_message">코드를 복사했어요.</string>
 
     <string name="group_add_description">그룹의 대표 사진을 추가해 주세요</string>
     <string name="group_add">이미지 추가</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -78,7 +78,7 @@
     <string name="group_member_list_title">그룹원</string>
     <string name="group_add_more_member">그룹원을 추가하고 싶으세요?</string>
     <string name="group_maximum_count">그룹 최대 인원은 6명이에요.</string>
-    <string name="button_copy_link">초대코드 복사</string>
+    <string name="button_copy_link">코드 복사</string>
     <string name="vote_icon">투표 아이콘</string>
     <string name="vote_dislike_desc">싫어요</string>
     <string name="vote_like_desc">좋아요</string>


### PR DESCRIPTION
## Issue No
- close #328 

## Overview (Required)
- 초대코드 복사 클릭 시 "링크를 복사했어요." 가 아니라 "코드를 복사했어요." 로 변경
- "초대코드 복사" => "코드 복사" 로 변경 필요

## Screenshot
Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/549f8a4f-fecd-483d-9d95-bf741b924747" width="300" /> | <img src="https://github.com/user-attachments/assets/c6d7ccd0-4f27-4a0e-b4f0-154d5255a72e" width="300" />

