### PR TITLE
[#326] 로그인화면 로띠가 너무 커요

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -67,9 +66,11 @@ fun LoginScreen(onClickLoginButton: () -> Unit) {
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.weight(0.4f))
-        PicIntroLottie(modifier = Modifier
-            .fillMaxWidth(0.6f)
-            .aspectRatio(1f))
+        PicIntroLottie(
+            modifier = Modifier
+                .fillMaxWidth(0.6f)
+                .aspectRatio(1f),
+        )
         Spacer(modifier = Modifier.weight(1f))
         KakaoLoginButton(
             modifier = Modifier

--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/login/LoginScreen.kt
@@ -8,11 +8,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -65,7 +67,9 @@ fun LoginScreen(onClickLoginButton: () -> Unit) {
             textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.weight(0.4f))
-        PicIntroLottie()
+        PicIntroLottie(modifier = Modifier
+            .fillMaxWidth(0.6f)
+            .aspectRatio(1f))
         Spacer(modifier = Modifier.weight(1f))
         KakaoLoginButton(
             modifier = Modifier
@@ -85,7 +89,10 @@ fun PicIntroLottie(
     )
 
     Box(modifier = modifier) {
-        LottieAnimation(composition)
+        LottieAnimation(
+            modifier = Modifier.fillMaxSize(),
+            composition = composition,
+        )
     }
 }
 


### PR DESCRIPTION
## Issue No
- close #326 

## Overview (Required)
- 로그인 로띠 크기 수정


## Screenshot
Figma
<img src="https://github.com/user-attachments/assets/7149b02d-7dc3-4543-a0e9-8882a0e7b00b" width="300" />

Before | After
:--: | :--:
<img src="https://github.com/user-attachments/assets/6f149191-6add-4358-a9ca-503da497fba0" width="300" /> | <img src="https://github.com/user-attachments/assets/7e41cb97-43a6-4faa-9546-c69da9be9c7a" width="300" />
