### PR TITLE
[#334] 이벤트 생성 화면에 로딩 인디케이터 겹침

### DIFF
--- a/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/detail/EventCreationDetailScreen.kt
+++ b/presentation/src/main/java/com/mashup/gabbangzip/sharedalbum/presentation/ui/eventcreation/detail/EventCreationDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.mashup.gabbangzip.sharedalbum.presentation.R
+import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray0Alpha80
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray60
 import com.mashup.gabbangzip.sharedalbum.presentation.theme.Gray80
@@ -184,7 +185,12 @@ fun EventCreationDetailScreen(
             },
         )
     }
-    PicLoadingIndicator(modifier = Modifier.fillMaxSize(), isVisible = state.isLoading)
+    PicLoadingIndicator(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Gray0),
+        isVisible = state.isLoading,
+    )
 }
 
 @Composable


### PR DESCRIPTION
## Issue No
- close #334 

## Overview (Required)
- 로딩 인디케이터 background 색상 설정

## Screenshot


https://github.com/user-attachments/assets/b00b3018-e3db-420f-b5a3-d7408c5e568f

